### PR TITLE
Update URL pattern instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add URL patterns
 
 ```python
 urlpatterns = [
-    url(r'^dj-rest-auth/', include('dj_rest_auth.urls'))
+    path('dj-rest-auth/', include('dj_rest_auth.urls')),
 ]
 ```
     


### PR DESCRIPTION
Move recommended way to add the authentication endpoint, from using `url` to using `path`.