### PR TITLE
Fix refresh cookie token bugs

### DIFF
--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -1,6 +1,6 @@
 from django.conf import settings
 from django.utils import timezone
-from rest_framework import exceptions
+from rest_framework import exceptions, serializers
 from rest_framework.authentication import CSRFCheck
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.serializers import TokenRefreshSerializer
@@ -44,7 +44,7 @@ def unset_jwt_cookies(response):
 
 
 class CookieTokenRefreshSerializer(TokenRefreshSerializer):
-    refresh = None
+    refresh = serializers.CharField(required=False)
 
     def extract_refresh_token(self):
         request = self.context['request']

--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -40,7 +40,13 @@ def set_jwt_cookies(response, access_token, refresh_token):
 
 
 def unset_jwt_cookies(response):
-    set_jwt_cookies(response, '', '')
+    cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
+    refresh_cookie_name = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE', None)
+
+    if cookie_name:
+        response.delete_cookie(cookie_name)
+    if refresh_cookie_name:
+        response.delete_cookie(refresh_cookie_name)
 
 
 class CookieTokenRefreshSerializer(TokenRefreshSerializer):

--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -44,12 +44,12 @@ def unset_jwt_cookies(response):
 
 
 class CookieTokenRefreshSerializer(TokenRefreshSerializer):
-    refresh = serializers.CharField(required=False)
+    refresh = serializers.CharField(blank=True)
 
     def extract_refresh_token(self):
         request = self.context['request']
         if 'refresh' in request.data and request.data['refresh'] != '':
-            return request['refresh']
+            return request.data['refresh']
         cookie_name = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE', None)
         if cookie_name:
             return request.COOKIES.get(cookie_name)

--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -42,11 +42,12 @@ def set_jwt_cookies(response, access_token, refresh_token):
 def unset_jwt_cookies(response):
     cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
     refresh_cookie_name = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE', None)
+    refresh_cookie_path = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE_PATH', '/')
 
     if cookie_name:
         response.delete_cookie(cookie_name)
     if refresh_cookie_name:
-        response.delete_cookie(refresh_cookie_name)
+        response.delete_cookie(refresh_cookie_name, path=refresh_cookie_path)
 
 
 class CookieTokenRefreshSerializer(TokenRefreshSerializer):

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -13,6 +13,7 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from jwt_auth import unset_jwt_cookies
 from .app_settings import (JWTSerializer, JWTSerializerWithExpiration, LoginSerializer,
                            PasswordChangeSerializer,
                            PasswordResetConfirmSerializer,
@@ -103,33 +104,8 @@ class LoginView(GenericAPIView):
 
         response = Response(serializer.data, status=status.HTTP_200_OK)
         if getattr(settings, 'REST_USE_JWT', False):
-            cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
-            refresh_cookie_name = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE', None)
-            refresh_cookie_path = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE_PATH', '/')
-            cookie_secure = getattr(settings, 'JWT_AUTH_SECURE', False)
-            cookie_httponly = getattr(settings, 'JWT_AUTH_HTTPONLY', True)
-            cookie_samesite = getattr(settings, 'JWT_AUTH_SAMESITE', 'Lax')
-
-            if cookie_name:
-                response.set_cookie(
-                    cookie_name,
-                    self.access_token,
-                    expires=access_token_expiration,
-                    secure=cookie_secure,
-                    httponly=cookie_httponly,
-                    samesite=cookie_samesite
-                )
-
-            if refresh_cookie_name:
-                response.set_cookie(
-                    refresh_cookie_name,
-                    self.refresh_token,
-                    expires=refresh_token_expiration,
-                    secure=cookie_secure,
-                    httponly=cookie_httponly,
-                    samesite=cookie_samesite,
-                    path=refresh_cookie_path
-                )
+            from jwt_auth import set_jwt_cookies
+            set_jwt_cookies(response, self.access_token, self.refresh_token)
         return response
 
     def post(self, request, *args, **kwargs):
@@ -182,36 +158,9 @@ class LogoutView(APIView):
             # True we shouldn't need the dependency
             from rest_framework_simplejwt.exceptions import TokenError
             from rest_framework_simplejwt.tokens import RefreshToken
-
             cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
-            refresh_cookie_name = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE', None)
-            refresh_cookie_path = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE_PATH', '/')
-            cookie_secure = getattr(settings, 'JWT_AUTH_SECURE', False)
-            cookie_httponly = getattr(settings, 'JWT_AUTH_HTTPONLY', True)
-            cookie_samesite = getattr(settings, 'JWT_AUTH_SAMESITE', 'Lax')
 
-            if cookie_name:
-                response.set_cookie(
-                    cookie_name,
-                    # self.access_token,
-                    max_age=0,
-                    expires='Thu, 01 Jan 1970 00:00:00 GMT',
-                    secure=cookie_secure,
-                    httponly=cookie_httponly,
-                    samesite=cookie_samesite
-                )
-
-            if refresh_cookie_name:
-                response.set_cookie(
-                    refresh_cookie_name,
-                    # self.refresh_token,
-                    max_age=0,
-                    expires='Thu, 01 Jan 1970 00:00:00 GMT',
-                    secure=cookie_secure,
-                    httponly=cookie_httponly,
-                    samesite=cookie_samesite,
-                    path=refresh_cookie_path
-                )
+            unset_jwt_cookies()
 
             if 'rest_framework_simplejwt.token_blacklist' in settings.INSTALLED_APPS:
                 # add refresh token to blacklist

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -13,7 +13,6 @@ from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from jwt_auth import unset_jwt_cookies
 from .app_settings import (JWTSerializer, JWTSerializerWithExpiration, LoginSerializer,
                            PasswordChangeSerializer,
                            PasswordResetConfirmSerializer,
@@ -104,7 +103,7 @@ class LoginView(GenericAPIView):
 
         response = Response(serializer.data, status=status.HTTP_200_OK)
         if getattr(settings, 'REST_USE_JWT', False):
-            from jwt_auth import set_jwt_cookies
+            from .jwt_auth import set_jwt_cookies
             set_jwt_cookies(response, self.access_token, self.refresh_token)
         return response
 
@@ -158,9 +157,10 @@ class LogoutView(APIView):
             # True we shouldn't need the dependency
             from rest_framework_simplejwt.exceptions import TokenError
             from rest_framework_simplejwt.tokens import RefreshToken
+            from .jwt_auth import unset_jwt_cookies
             cookie_name = getattr(settings, 'JWT_AUTH_COOKIE', None)
 
-            unset_jwt_cookies()
+            unset_jwt_cookies(response)
 
             if 'rest_framework_simplejwt.token_blacklist' in settings.INSTALLED_APPS:
                 # add refresh token to blacklist


### PR DESCRIPTION
There was a bug in which `/token/refresh/` did not read and update the refresh token cookie. A small refactoring is also included. 