### PR TITLE
Update docs to include mention of JWT_AUTH_REFRESH_COOKIE

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -57,6 +57,7 @@ Configuration
 - **REST_SESSION_LOGIN** - Enable session login in Login API view (default: True)
 - **REST_USE_JWT** - Enable JWT Authentication instead of Token/Session based. This is built on top of djangorestframework-simplejwt https://github.com/SimpleJWT/django-rest-framework-simplejwt, which must also be installed. (default: False)
 - **JWT_AUTH_COOKIE** - The cookie name/key.
+- **JWT_AUTH_REFRESH_COOKIE** - The name/key of the refresh token. ``None`` when not set, which disables the refresh token.
 - **JWT_AUTH_SECURE** - If you want the cookie to be only sent to the server when a request is made with the https scheme (default: False).
 - **JWT_AUTH_HTTPONLY** - If you want to prevent client-side JavaScript from having access to the cookie (default: True).
 - **JWT_AUTH_SAMESITE** - To tell the browser not to send this cookie when performing a cross-origin request (default: 'Lax'). SameSite isn’t supported by all browsers.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -271,11 +271,12 @@ By default ``dj-rest-auth`` uses Django's Token-based authentication. If you wan
 
     REST_USE_JWT = True
 
-4. Declare what you want the cookie key to be called.
+4. Declare what you want the cookie key to be called. If you want to use the refresh token feature, also be sure to set that variable.
 
 .. code-block:: python
 
     JWT_AUTH_COOKIE = 'my-app-auth'
+    JWT_AUTH_REFRESH_COOKIE = 'my-refresh-token'
 
 
 This example value above will cause dj-rest-auth to return a `Set-Cookie` header that looks like this:
@@ -284,4 +285,4 @@ This example value above will cause dj-rest-auth to return a `Set-Cookie` header
 
     Set-Cookie: my-app-auth=xxxxxxxxxxxxx; expires=Sat, 28 Mar 2020 18:59:00 GMT; HttpOnly; Max-Age=300; Path=/
 
-``JWT_AUTH_COOKIE`` is also used while authenticating each request against protected views.
+If ``JWT_AUTH_REFRESH_COOKIE`` is also set, it will also set a comperable cookie for that. ``JWT_AUTH_COOKIE`` is also used while authenticating each request against protected views.


### PR DESCRIPTION
As mentioned in #190, the refresh token is not set when not using ``JWT_AUTH_REFRESH_COOKIE``, which is not mentioned in the docs. This PR is meant to include that setting in the documentation.