### PR TITLE
Use "first_name" and "last_name" only if the UserModel has them

### DIFF
--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -169,9 +169,13 @@ class UserDetailsSerializer(serializers.ModelSerializer):
             extra_fields.append(UserModel.USERNAME_FIELD)
         if hasattr(UserModel, "EMAIL_FIELD"):
             extra_fields.append(UserModel.EMAIL_FIELD)
+        if hasattr(UserModel, "first_name"):
+            extra_fields.append('first_name')
+        if hasattr(UserModel, "last_name"):
+            extra_fields.append('last_name')
 
         model = UserModel
-        fields = ('pk', *extra_fields, 'first_name', 'last_name')
+        fields = ('pk', *extra_fields)
         read_only_fields = ('email',)
 
 


### PR DESCRIPTION
Similar to the issue https://github.com/iMerica/dj-rest-auth/issues/181, dj-rest=auth was not loading my custom UserDetailsSerializer and when I use the default one there are two fields that my UserModel does not have. We should not enforce people to have this fields either and therefore I have done the same as the previous PR but with "first_name" and "last_name"