### PR TITLE
Fix: 'str' object has no attribute 'decode'

### DIFF
--- a/demo/requirements.pip
+++ b/demo/requirements.pip
@@ -1,7 +1,7 @@
 django>=2.2
 dj-rest-auth @ git+https://github.com/iMerica/dj-rest-auth.git@master
 djangorestframework>=3.11.0
-djangorestframework-simplejwt==4.4.0
+djangorestframework-simplejwt==4.6.0
 django-allauth>=0.24.1
 drf-yasg==1.20.0
 django-cors-headers==3.2.1


### PR DESCRIPTION
The issues with simplejwt is described here: https://github.com/jazzband/django-rest-framework-simplejwt/issues/326
Please verify for good measure!