### PR TITLE
Use allauth uid encoding if installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ JWT_AUTH_COOKIE = 'jwt-auth'
 
 ### Testing
 
+Install required modules with `pip install -r  dj_rest_auth/tests/requirements.pip`
+
 To run the tests within a virtualenv, run `python runtests.py` from the repository directory.
 The easiest way to run test coverage is with [`coverage`](https://pypi.org/project/coverage/),
 which runs the tests against all supported Django installs. To run the test coverage 

--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -1,9 +1,7 @@
 from django.conf import settings
 from django.contrib.auth import authenticate, get_user_model
 from django.contrib.auth.forms import PasswordResetForm, SetPasswordForm
-from django.contrib.auth.tokens import default_token_generator
 from django.utils.encoding import force_str
-from django.utils.http import urlsafe_base64_decode as uid_decoder
 from django.utils.module_loading import import_string
 
 
@@ -11,6 +9,13 @@ try:
     from django.utils.translation import gettext_lazy as _
 except ImportError:
     from django.utils.translation import gettext_lazy as _
+
+if 'allauth' in settings.INSTALLED_APPS:
+    from allauth.account.forms import default_token_generator
+    from allauth.account.utils import url_str_to_user_pk as uid_decoder
+else:
+    from django.contrib.auth.tokens import default_token_generator 
+    from django.utils.http import urlsafe_base64_decode as uid_decoder
 
 from rest_framework import exceptions, serializers
 from rest_framework.exceptions import ValidationError

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -8,7 +8,6 @@ from django.test import TestCase, override_settings
 from django.utils.encoding import force_str
 from rest_framework import status
 from rest_framework.test import APIRequestFactory
-
 from dj_rest_auth.registration.app_settings import register_permission_classes
 from dj_rest_auth.registration.views import RegisterView
 
@@ -74,11 +73,15 @@ class APIBasicTests(TestsMixin, TestCase):
 
     def _generate_uid_and_token(self, user):
         result = {}
-        from django.contrib.auth.tokens import default_token_generator
-        from django.utils.encoding import force_bytes
-        from django.utils.http import urlsafe_base64_encode
-
-        result['uid'] = urlsafe_base64_encode(force_bytes(user.pk))
+        if 'allauth' in settings.INSTALLED_APPS:
+            from allauth.account.forms import default_token_generator
+            from allauth.account.utils import user_pk_to_url_str
+            result['uid'] = user_pk_to_url_str(user)
+        else:
+            from django.utils.encoding import force_bytes
+            from django.contrib.auth.tokens import default_token_generator 
+            from django.utils.http import urlsafe_base64_encode
+            result['uid'] = urlsafe_base64_encode(force_bytes(user.pk))
         result['token'] = default_token_generator.make_token(user)
         return result
 


### PR DESCRIPTION
This PR overrides #258 and fixes #76

Highlights:

- use token generator and uid decoder from Allauth if it is in installed apps
- fix test by using Allauth token generator and uid encoder  if allauth app is installed
- add note in README how to setup test environment, I missed that ;-)

All tests pass, coverage is unchanged