### PR TITLE
fix the problem password_reset_confirm

### DIFF
--- a/dj_rest_auth/urls.py
+++ b/dj_rest_auth/urls.py
@@ -10,7 +10,7 @@ from dj_rest_auth.views import (
 urlpatterns = [
     # URLs that do not require a session or valid token
     path('password/reset/', PasswordResetView.as_view(), name='rest_password_reset'),
-    path('password/reset/confirm/', PasswordResetConfirmView.as_view(), name='rest_password_reset_confirm'),
+    path('password/reset/confirm/<uidb64>/<token>/', PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
     path('login/', LoginView.as_view(), name='rest_login'),
     # URLs that require a user to be logged in with a valid session / token.
     path('logout/', LogoutView.as_view(), name='rest_logout'),


### PR DESCRIPTION
Solving common problems with the changes I did
Reverse for 'password_reset_confirm' not found. 'password_reset_confirm' is not a valid view function or pattern name.
 Reverse for 'password_reset_confirm' with keyword arguments '{'uidb64': 'Mg', 'token': 'ao93ci-4b3be5504101f6f50dc72cf9112806b2'}' not found