### PR TITLE
Fix the problem password_reset_confirm

### DIFF
--- a/demo/templates/fragments/password_reset_confirm_form.html
+++ b/demo/templates/fragments/password_reset_confirm_form.html
@@ -1,5 +1,5 @@
 <!-- Signup form -->
-<form class="form-horizontal ajax-post" role="form" action="{% url 'rest_password_reset_confirm' %}">{% csrf_token %}
+<form class="form-horizontal ajax-post" role="form" action="{% url 'password_reset_confirm' %}">{% csrf_token %}
   <div class="form-group">
     <label for="uid" class="col-sm-2 control-label">Uid</label>
     <div class="col-sm-10">

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -313,7 +313,7 @@ class APIBasicTests(TestsMixin, TestCase):
         self.assertEqual(len(mail.outbox), mail_count + 1)
 
         url_kwargs = self._generate_uid_and_token(user)
-        url = reverse('rest_password_reset_confirm')
+        url = reverse('password_reset_confirm')
 
         # wrong token
         data = {
@@ -349,7 +349,7 @@ class APIBasicTests(TestsMixin, TestCase):
             'uid': force_str(url_kwargs['uid']),
             'token': url_kwargs['token'],
         }
-        url = reverse('rest_password_reset_confirm')
+        url = reverse('password_reset_confirm')
         self.post(url, data=data, status_code=200)
 
         payload = {

--- a/dj_rest_auth/urls.py
+++ b/dj_rest_auth/urls.py
@@ -10,7 +10,7 @@ from dj_rest_auth.views import (
 urlpatterns = [
     # URLs that do not require a session or valid token
     path('password/reset/', PasswordResetView.as_view(), name='rest_password_reset'),
-    path('password/reset/confirm/', PasswordResetConfirmView.as_view(), name='rest_password_reset_confirm'),
+    path('password/reset/confirm/<uidb64>/<token>/', PasswordResetConfirmView.as_view(), name='password_reset_confirm'),
     path('login/', LoginView.as_view(), name='rest_login'),
     # URLs that require a user to be logged in with a valid session / token.
     path('logout/', LogoutView.as_view(), name='rest_logout'),


### PR DESCRIPTION
Solving common problems with the changes I did : 

Reverse for 'password_reset_confirm' not found. 'password_reset_confirm' is not a valid view function or pattern name.

Reverse for 'password_reset_confirm' with keyword arguments '{'uidb64': 'Mg', 'token': 'ao93ci-4b3be5504101f6f50dc72cf9112806b2'}' not found