### PR TITLE
Fixed token invalidation on password change

### DIFF
--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -348,7 +348,7 @@ class PasswordChangeSerializer(serializers.Serializer):
             raise serializers.ValidationError(self.set_password_form.errors)
         return attrs
 
-    def save(self):        
+    def save(self):
         self.set_password_form.save()
         if not self.logout_on_password_change:
             # Get current user

--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -348,8 +348,12 @@ class PasswordChangeSerializer(serializers.Serializer):
             raise serializers.ValidationError(self.set_password_form.errors)
         return attrs
 
-    def save(self):
+    def save(self):        
         self.set_password_form.save()
         if not self.logout_on_password_change:
+            # Get current user
+            user = self.context['request'].user
+            # Invalidate the token
+            user.auth_token.delete()
             from django.contrib.auth import update_session_auth_hash
             update_session_auth_hash(self.request, self.user)


### PR DESCRIPTION
When `LOGOUT_ON_PASSWORD_CHANGE=True`, we now delete the current user's token to ensure no more API calls are made.