### PR TITLE
Adding support for Access and Refresh Cookie Domains

### DIFF
--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -13,6 +13,7 @@ def set_jwt_access_cookie(response, access_token):
     cookie_secure = getattr(settings, 'JWT_AUTH_SECURE', False)
     cookie_httponly = getattr(settings, 'JWT_AUTH_HTTPONLY', True)
     cookie_samesite = getattr(settings, 'JWT_AUTH_SAMESITE', 'Lax')
+    cookie_domain = getattr(settings, "JWT_AUTH__COOKIE_DOMAIN", None)
 
     if cookie_name:
         response.set_cookie(
@@ -22,6 +23,7 @@ def set_jwt_access_cookie(response, access_token):
             secure=cookie_secure,
             httponly=cookie_httponly,
             samesite=cookie_samesite,
+            domain = cookie_domain
         )
 
 
@@ -33,6 +35,7 @@ def set_jwt_refresh_cookie(response, refresh_token):
     cookie_secure = getattr(settings, 'JWT_AUTH_SECURE', False)
     cookie_httponly = getattr(settings, 'JWT_AUTH_HTTPONLY', True)
     cookie_samesite = getattr(settings, 'JWT_AUTH_SAMESITE', 'Lax')
+    cookie_domain = getattr(settings, "JWT_AUTH__COOKIE_DOMAIN", None)
 
     if refresh_cookie_name:
         response.set_cookie(
@@ -43,6 +46,7 @@ def set_jwt_refresh_cookie(response, refresh_token):
             httponly=cookie_httponly,
             samesite=cookie_samesite,
             path=refresh_cookie_path,
+            domain = cookie_domain
         )
 
 

--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -13,7 +13,7 @@ def set_jwt_access_cookie(response, access_token):
     cookie_secure = getattr(settings, 'JWT_AUTH_SECURE', False)
     cookie_httponly = getattr(settings, 'JWT_AUTH_HTTPONLY', True)
     cookie_samesite = getattr(settings, 'JWT_AUTH_SAMESITE', 'Lax')
-    cookie_domain = getattr(settings, "JWT_AUTH__COOKIE_DOMAIN", None)
+    cookie_domain = getattr(settings, "JWT_AUTH_COOKIE_DOMAIN", None)
 
     if cookie_name:
         response.set_cookie(

--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -35,7 +35,7 @@ def set_jwt_refresh_cookie(response, refresh_token):
     cookie_secure = getattr(settings, 'JWT_AUTH_SECURE', False)
     cookie_httponly = getattr(settings, 'JWT_AUTH_HTTPONLY', True)
     cookie_samesite = getattr(settings, 'JWT_AUTH_SAMESITE', 'Lax')
-    cookie_domain = getattr(settings, "JWT_AUTH__COOKIE_DOMAIN", None)
+    cookie_domain = getattr(settings, "JWT_AUTH_COOKIE_DOMAIN", None)
 
     if refresh_cookie_name:
         response.set_cookie(

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,6 +61,7 @@ Configuration
 - **JWT_AUTH_SECURE** - If you want the cookie to be only sent to the server when a request is made with the https scheme (default: False).
 - **JWT_AUTH_HTTPONLY** - If you want to prevent client-side JavaScript from having access to the cookie (default: True).
 - **JWT_AUTH_SAMESITE** - To tell the browser not to send this cookie when performing a cross-origin request (default: 'Lax'). SameSite isn’t supported by all browsers.
+- **JWT_AUTH_DOMAIN** - Sets the domain for JWT refresh and access cookies
 - **OLD_PASSWORD_FIELD_ENABLED** - set it to True if you want to have old password verification on password change enpoint (default: False)
 - **LOGOUT_ON_PASSWORD_CHANGE** - set to False if you want to keep the current user logged in after a password change
 - **JWT_AUTH_COOKIE_USE_CSRF** -  Enables CSRF checks for only authenticated views when using the JWT cookie for auth. Does not effect a client's ability to authenticate using a JWT Bearer Auth header without a CSRF token.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,7 +61,7 @@ Configuration
 - **JWT_AUTH_SECURE** - If you want the cookie to be only sent to the server when a request is made with the https scheme (default: False).
 - **JWT_AUTH_HTTPONLY** - If you want to prevent client-side JavaScript from having access to the cookie (default: True).
 - **JWT_AUTH_SAMESITE** - To tell the browser not to send this cookie when performing a cross-origin request (default: 'Lax'). SameSite isn’t supported by all browsers.
-- **JWT_AUTH_DOMAIN** - Sets the domain for JWT refresh and access cookies
+- **JWT_AUTH_COOKIE_DOMAIN** - Sets the domain for JWT refresh and access cookies
 - **OLD_PASSWORD_FIELD_ENABLED** - set it to True if you want to have old password verification on password change enpoint (default: False)
 - **LOGOUT_ON_PASSWORD_CHANGE** - set to False if you want to keep the current user logged in after a password change
 - **JWT_AUTH_COOKIE_USE_CSRF** -  Enables CSRF checks for only authenticated views when using the JWT cookie for auth. Does not effect a client's ability to authenticate using a JWT Bearer Auth header without a CSRF token.


### PR DESCRIPTION
Hello.
basically solving the issue in #238 
the reasoning behind defining `JWT_AUTH_COOKIE_DOMAIN` instead of using Django's `SESSION_COOKIE_DOMAIN ` was to give end-users more freedom in customization and not to mess with Django's session cookies. 