### PR TITLE
ResendEmailVerificationView requires queryset

### DIFF
--- a/dj_rest_auth/registration/views.py
+++ b/dj_rest_auth/registration/views.py
@@ -118,15 +118,10 @@ class ResendEmailVerificationView(CreateAPIView):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        try:
-            email = EmailAddress.objects.get(**serializer.validated_data)
-        except EmailAddress.DoesNotExist:
-            raise ValidationError("Account does not exist")
+        email = EmailAddress.objects.filter(**serializer.validated_data).first()
+        if email and not email.verified:
+            email.send_confirmation()
 
-        if email.verified:
-            raise ValidationError("Account is already verified")
-
-        email.send_confirmation()
         return Response({'detail': _('ok')}, status=status.HTTP_200_OK)
 
 

--- a/dj_rest_auth/registration/views.py
+++ b/dj_rest_auth/registration/views.py
@@ -112,13 +112,15 @@ class VerifyEmailView(APIView, ConfirmEmailView):
 class ResendEmailVerificationView(CreateAPIView):
     permission_classes = (AllowAny,)
     serializer_class = ResendEmailVerificationSerializer
+    queryset = EmailAddress.objects.all()
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        email = EmailAddress.objects.get(**serializer.validated_data)
-        if not email:
+        try:
+            email = EmailAddress.objects.get(**serializer.validated_data)
+        except EmailAddress.DoesNotExist:
             raise ValidationError("Account does not exist")
 
         if email.verified:


### PR DESCRIPTION
https://github.com/iMerica/dj-rest-auth/issues/44#issuecomment-922257789

## Problems
* When POSTed `email` to ResendemailVerificationView, we get `'ResendEmailVerificationView' should either include a queryset attribute, or override the get_queryset() method.` error.
* When the email POSTed does not exist in the system, `EmailAddress.DoesNotExist` exception is raised.

## Solution

* `ResendEmailVerificationView` requires `queryset` attribute since it extends `CreateAPIView`
* `ResendEmailVerificationView` uses `filter().first()` to avoid exception in cases email does not exist in the database. `EmailAddress.objects.get()` raises exception, instead of returning `False`.
* Don't expose that the email exists and already verified or it does not exist in the system. Avoid leaks like we do in password reset.
* Add tests to check we only send e-mail when needed: email exists and not verified. In other cases no email sent but the response is 200.