### PR TITLE
Add request to email.send_confirmation() in ResendEmailVerificationView

### DIFF
--- a/dj_rest_auth/registration/views.py
+++ b/dj_rest_auth/registration/views.py
@@ -124,7 +124,7 @@ class ResendEmailVerificationView(CreateAPIView):
         if email.verified:
             raise ValidationError("Account is already verified")
 
-        email.send_confirmation()
+        email.send_confirmation(request)
         return Response({'detail': _('ok')}, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
Add `request` as parameter to `email.send_confirmation()` in `ResendEmailVerificationView` to allow url of the current website to be the target url for the email verification link.
Without `request` it defaults to `django.contrib.sites.Site`, which is configured in the database, and will not match current website url, like all other email links currently do this.