### PR TITLE
Add request to email.send_confirmation() in ResendEmailVerificationView

### DIFF
--- a/dj_rest_auth/registration/views.py
+++ b/dj_rest_auth/registration/views.py
@@ -124,7 +124,7 @@ class ResendEmailVerificationView(CreateAPIView):
         if email.verified:
             raise ValidationError("Account is already verified")
 
-        email.send_confirmation()
+        email.send_confirmation(request)
         return Response({'detail': _('ok')}, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
**Why?**
Currently the email activation which is send when you request to resend the email verification link, the new link uses the domain specified in Djangos Sites package in the database. This links domain therefore might not be the same as the original email verification link.

For example:
Original email verification link: `http://localhost:8000/verify-email/<key>/`
Resend email verification link: `http://example.com/verify-email/<key>/`

This could be easily 

**Proposed Fix**
Add `request` as parameter to `email.send_confirmation()` in `ResendEmailVerificationView` to allow url of the current website to be the target url for the email verification link (see below).

**Debugging Trace**
- ResendEmailVerificationView (line 127)
- EmailAddress.send_confirmation (allauth/account/models.py line 57)
- EmailConfirmation.send  (allauth/account/models.py line 123)
- DefaultAccountAdapter.send_confirmation_mail (allauth/account/adapter.py line 451)
- DefaultAccountAdapter.get_email_confirmation_url (allauth/account/adapter.py line 440)
- build_absolute_uri (allauth/utils.py line 265) (see below)
```
def build_absolute_uri(request, location, protocol=None):
[...]
    if request is None:
        site = Site.objects.get_current() <-- this is what happens, which fetches the website domain from the database
        [...]
    else:
        uri = request.build_absolute_uri(location) <-- this would be expected, because we could pass the request from the ResendEmailVerificationView and therefore use the domain the user used to request resend
```