### PR TITLE
Fix missing registration url

### DIFF
--- a/dj_rest_auth/registration/urls.py
+++ b/dj_rest_auth/registration/urls.py
@@ -24,4 +24,8 @@ urlpatterns = [
         r'^account-confirm-email/(?P<key>[-:\w]+)/$', TemplateView.as_view(),
         name='account_confirm_email',
     ),
+    path(
+        r'^account-email-verification-sent/$', TemplateView.as_view(),
+        name='account_email_verification_sent',
+    ),
 ]


### PR DESCRIPTION
`registration/url.py` is missing an URL that is required by allauth in order to finish registration with email verication enabled (at least if `ACCOUNT_EMAIL_VERIFICATION = True `). This URL is configured in `tests/urls.py`, which explainst why the test succeed.