### PR TITLE
Convert allauth's OAuth2Error to serializer validation error

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -14,6 +14,7 @@ try:
     from allauth.socialaccount.helpers import complete_social_login
     from allauth.socialaccount.models import SocialAccount
     from allauth.socialaccount.providers.base import AuthProcess
+    from allauth.socialaccount.providers.oauth2.client import OAuth2Error
     from allauth.utils import email_address_exists, get_username_max_length
 except ImportError:
     raise ImportError('allauth needs to be added to INSTALLED_APPS.')
@@ -130,7 +131,12 @@ class SocialLoginSerializer(serializers.Serializer):
                 headers=adapter.headers,
                 basic_auth=adapter.basic_auth,
             )
-            token = client.get_access_token(code)
+            try:
+                token = client.get_access_token(code)
+            except OAuth2Error:
+                raise serializers.ValidationError(
+                    _("Invalid code"),
+                )
             access_token = token['access_token']
             tokens_to_parse = {'access_token': access_token}
 


### PR DESCRIPTION
Signed-off-by: Samhita Alla <aallasamhita@gmail.com>

Hopefully, this PR fixes the 500 server error that pops up when the "code" given for GitHub authentication is invalid.

<img width="1416" alt="Screenshot 2021-12-10 at 12 30 02 PM" src="https://user-images.githubusercontent.com/27777173/145531588-c6926259-5f36-41d2-b154-71f345426c8c.png">
<img width="1172" alt="Screenshot 2021-12-10 at 12 32 36 PM" src="https://user-images.githubusercontent.com/27777173/145531596-7ad71711-2ab5-4bb7-8a37-2dac53d3cbe1.png">
