### PR TITLE
Test run fails with Django 4

### DIFF
--- a/dj_rest_auth/tests/requirements.pip
+++ b/dj_rest_auth/tests/requirements.pip
@@ -4,3 +4,4 @@ djangorestframework-simplejwt==4.6.0
 flake8==3.8.4
 responses==0.12.1
 unittest-xml-reporting==3.0.4
+django>=2.2,<=3


### PR DESCRIPTION
Test failing since allauth (0.42.0) is compatible only with Django<=3. Django4 has been released in Dec 2021 and running the current tests requirements.pip with `pip install -r dj_rest_auth/tests/requirements.pip` installs Django4 by default.

Following the error I'm getting after making a fresh install and running it on a virtual env.:

`from . import app_settings, signals
  File "....\dj-rest-auth\venv\lib\site-packages\allauth\account\signals.py", line 5, in <module>
    user_logged_in = Signal(providing_args=["request", "user"])
TypeError: __init__() got an unexpected keyword argument 'providing_args'`