### PR TITLE
remove regex in static path, silences django warn

### DIFF
--- a/dj_rest_auth/registration/urls.py
+++ b/dj_rest_auth/registration/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
         name='account_confirm_email',
     ),
     path(
-        r'^account-email-verification-sent/$', TemplateView.as_view(),
+        'account-email-verification-sent/', TemplateView.as_view(),
         name='account_email_verification_sent',
     ),
 ]


### PR DESCRIPTION
The leftover regex after switching to path creates a django warning.