### PR TITLE
Allow users to use up to django-allauth v0.47.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,11 @@ setup(
         'djangorestframework>=3.7.0',
     ],
     extras_require={
-        'with_social': ['django-allauth>=0.40.0,<0.45.0'],
+        'with_social': ['django-allauth>=0.40.0,<0.48.0'],
     },
     tests_require=[
         'coveralls>=1.11.1',
-        'django-allauth==0.42.0',
+        'django-allauth==0.47.0',
         'djangorestframework-simplejwt==4.6.0',
         'responses==0.12.1',
         'unittest-xml-reporting==3.0.4',


### PR DESCRIPTION
The current `django-allauth` version pinning `django-allauth>=0.40.0,<0.45.0` limits the version of `django-allauth` to `0.44.x` which:

1. Is incompatible with Django [`3.2`](https://github.com/pennersr/django-allauth/blob/0.46.0/ChangeLog.rst),
2. Has various [security notices](https://github.com/pennersr/django-allauth/blob/master/ChangeLog.rst#security-notice).

This PR allows the use of the latest and greatest `django-allauth` `0.47` when a user installs `dj-rest-auth[with_social]`.

---

Fixes #353 and #330 