### PR TITLE
feat: allow for use of django.contrib.sites domain in password reset e-mail

### DIFF
--- a/dj_rest_auth/forms.py
+++ b/dj_rest_auth/forms.py
@@ -43,7 +43,11 @@ class AllAuthPasswordResetForm(DefaultPasswordResetForm):
                 'password_reset_confirm',
                 args=[user_pk_to_url_str(user), temp_key],
             )
-            url = build_absolute_uri(request, path)
+
+            if settings.REST_AUTH_PW_RESET_USE_SITES_DOMAIN is True:
+                url = build_absolute_uri(None, path)
+            else:
+                url = build_absolute_uri(request, path)
 
             context = {
                 'current_site': current_site,

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -55,7 +55,7 @@ Configuration
 - **REST_AUTH_TOKEN_MODEL** - path to model class for tokens, default value ``'rest_framework.authtoken.models.Token'``
   If set to ``None`` token authentication will be disabled. In this case at least one of REST_SESSION_LOGIN or REST_USE_JWT must be enabled.
 - **REST_AUTH_TOKEN_CREATOR** - path to callable or callable for creating tokens, default value ``dj_rest_auth.utils.default_create_token``.
-- **REST_AUTH_USE_SITES_DOMAIN_IN_EMAILS** - if set to ``True``, the domain in the password reset e-mail will be set to the domain you defined in ``django.contrib.sites`` module with ``SITE_ID=1``
+- **REST_AUTH_PW_RESET_USE_SITES_DOMAIN** - if set to ``True``, the domain in the password reset e-mail will be set to the domain you defined in ``django.contrib.sites`` module with ``SITE_ID=1``
 - **REST_SESSION_LOGIN** - Enable session login in Login API view (default: True)
 - **REST_USE_JWT** - Enable JWT Authentication instead of Token/Session based. This is built on top of djangorestframework-simplejwt https://github.com/SimpleJWT/django-rest-framework-simplejwt, which must also be installed. (default: False)
 - **JWT_AUTH_COOKIE** - The cookie name/key.

--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -55,6 +55,7 @@ Configuration
 - **REST_AUTH_TOKEN_MODEL** - path to model class for tokens, default value ``'rest_framework.authtoken.models.Token'``
   If set to ``None`` token authentication will be disabled. In this case at least one of REST_SESSION_LOGIN or REST_USE_JWT must be enabled.
 - **REST_AUTH_TOKEN_CREATOR** - path to callable or callable for creating tokens, default value ``dj_rest_auth.utils.default_create_token``.
+- **REST_AUTH_USE_SITES_DOMAIN_IN_EMAILS** - if set to ``True``, the domain in the password reset e-mail will be set to the domain you defined in ``django.contrib.sites`` module with ``SITE_ID=1``
 - **REST_SESSION_LOGIN** - Enable session login in Login API view (default: True)
 - **REST_USE_JWT** - Enable JWT Authentication instead of Token/Session based. This is built on top of djangorestframework-simplejwt https://github.com/SimpleJWT/django-rest-framework-simplejwt, which must also be installed. (default: False)
 - **JWT_AUTH_COOKIE** - The cookie name/key.


### PR DESCRIPTION
See #355