### PR TITLE
Add custom validation to password change serializer

### DIFF
--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -345,11 +345,15 @@ class PasswordChangeSerializer(serializers.Serializer):
             raise serializers.ValidationError(err_msg)
         return value
 
+    def custom_validation(self, attrs):
+        pass
+
     def validate(self, attrs):
         self.set_password_form = self.set_password_form_class(
             user=self.user, data=attrs,
         )
 
+        self.custom_validation(attrs)
         if not self.set_password_form.is_valid():
             raise serializers.ValidationError(self.set_password_form.errors)
         return attrs


### PR DESCRIPTION
`PasswordResetConfirmSerializer` provides a `custom_validation` method that allows to trivially add custom validation for derived serializers. `PasswordChangeSerializer` didn't provide this method up to now, which could lead to inconsistencies in the password validation mechanism between password reset and password change. This pull request fixes this inconsistency and allows custom validation for password change as well.