### PR TITLE
Updated import for Google Social Authentication

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -213,7 +213,7 @@ If you are using Google for your social authentication, the OAuth flow is ``Hybr
 
 .. code-block:: python
 
-    from allauth.socialaccount.providers.github.views import GoogleOAuth2Adapter
+    from allauth.socialaccount.providers.google.views import GoogleOAuth2Adapter
     from allauth.socialaccount.providers.oauth2.client import OAuth2Client
     from dj_rest_auth.registration.views import SocialLoginView
     


### PR DESCRIPTION
Just correcting an error I noticed in the supplied imports for the Google social authentication. The initial import was pointing the 'github.views' instead of 'google.views'.