### PR TITLE
Allow Registration with no password

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -237,7 +237,7 @@ class RegisterSerializer(serializers.Serializer):
         user = adapter.new_user(request)
         self.cleaned_data = self.get_cleaned_data()
         user = adapter.save_user(request, user, self, commit=False)
-        if self.cleaned_data.get('password1'):
+        if "password1" in self.cleaned_data:
             try:
                 adapter.clean_password(self.cleaned_data['password1'], user=user)
             except DjangoValidationError as exc:

--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -237,11 +237,12 @@ class RegisterSerializer(serializers.Serializer):
         user = adapter.new_user(request)
         self.cleaned_data = self.get_cleaned_data()
         user = adapter.save_user(request, user, self, commit=False)
-        try:
-            adapter.clean_password(self.cleaned_data['password1'], user=user)
-        except DjangoValidationError as exc:
-            raise serializers.ValidationError(
-                detail=serializers.as_serializer_error(exc)
+        if self.cleaned_data.get('password1'):
+            try:
+                adapter.clean_password(self.cleaned_data['password1'], user=user)
+            except DjangoValidationError as exc:
+                raise serializers.ValidationError(
+                    detail=serializers.as_serializer_error(exc)
             )
         user.save()
         self.custom_signup(request, user)

--- a/dj_rest_auth/tests/mixins.py
+++ b/dj_rest_auth/tests/mixins.py
@@ -81,6 +81,7 @@ class TestsMixin:
         self.logout_url = reverse('rest_logout')
         self.password_change_url = reverse('rest_password_change')
         self.register_url = reverse('rest_register')
+        self.no_password_register_url = reverse('no_password_rest_register')
         self.password_reset_url = reverse('rest_password_reset')
         self.user_url = reverse('rest_user_details')
         self.verify_email_url = reverse('rest_verify_email')

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -11,9 +11,7 @@ from rest_framework import status
 from rest_framework.test import APIRequestFactory
 from dj_rest_auth.registration.app_settings import register_permission_classes
 from dj_rest_auth.registration.views import RegisterView
-from dj_rest_auth.registration.serializers import RegisterSerializer
 from dj_rest_auth.models import get_token_model
-from rest_framework.serializers import CharField
 from .mixins import CustomPermissionClass, TestsMixin
 
 try:
@@ -481,23 +479,10 @@ class APIBasicTests(TestsMixin, TestCase):
         }
         user_count = get_user_model().objects.all().count()
 
-        class CustomRegisterSerializer(RegisterSerializer):
-            password1 = CharField(write_only=True, default=None)
-            password2 = CharField(write_only=True, default=None)
+        # test empty payload
+        self.post(self.no_password_register_url, data={}, status_code=400)
 
-            def get_cleaned_data(self):
-                data = {
-                    "username": self.validated_data.get("username", ""),
-                    "email": self.validated_data.get("email", ""),
-                }
-
-        class CustomRegisterView(RegisterView):
-            serializer_class = CustomRegisterSerializer
-
-        factory = APIRequestFactory()
-        request = factory.post(self.register_url, payload, format='json')
-        result = CustomRegisterView.as_view()(request)
-
+        result = self.post(self.no_password_register_url, data=payload, status_code=201)
         self.assertIn('key', result.data)
         self.assertEqual(get_user_model().objects.all().count(), user_count + 1)
 

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -490,6 +490,20 @@ class APIBasicTests(TestsMixin, TestCase):
         self.assertEqual(new_user.username, payload['username'])
         self.assertFalse(new_user.has_usable_password())
 
+        ## Also check that regular registration also works
+        user_count = get_user_model().objects.all().count()
+
+        # test empty payload
+        self.post(self.register_url, data={}, status_code=400)
+
+        result = self.post(self.register_url, data=self.REGISTRATION_DATA, status_code=201)
+        self.assertIn('key', result.data)
+        self.assertEqual(get_user_model().objects.all().count(), user_count + 1)
+
+        new_user = get_user_model().objects.latest('id')
+        self.assertEqual(new_user.username, self.REGISTRATION_DATA['username'])
+
+
     @override_settings(REST_USE_JWT=True)
     def test_registration_with_jwt(self):
         user_count = get_user_model().objects.all().count()


### PR DESCRIPTION
[`django-allauth` account adapters allow creating a user with no password](https://github.com/pennersr/django-allauth/blob/ced1ddc730c36eca3551406c60e1577e30e01cbd/allauth/account/adapter.py#L241). 

https://github.com/iMerica/dj-rest-auth/pull/277 broke using this functionality. This PR re-adds it by only running password validation if a password is present in cleaned data