### PR TITLE
Removes refresh_token from body when JWT_AUTH_HTTPONLY is set

### DIFF
--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -57,9 +57,9 @@ def unset_jwt_cookies(response):
     refresh_cookie_path = getattr(settings, 'JWT_AUTH_REFRESH_COOKIE_PATH', '/')
 
     if cookie_name:
-        response.delete_cookie(cookie_name)
+        response.delete_cookie(cookie_name, samesite=None)
     if refresh_cookie_name:
-        response.delete_cookie(refresh_cookie_name, path=refresh_cookie_path)
+        response.delete_cookie(refresh_cookie_name, path=refresh_cookie_path, samesite=None)
 
 
 class CookieTokenRefreshSerializer(TokenRefreshSerializer):

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -89,12 +89,18 @@ class LoginView(GenericAPIView):
             access_token_expiration = (timezone.now() + jwt_settings.ACCESS_TOKEN_LIFETIME)
             refresh_token_expiration = (timezone.now() + jwt_settings.REFRESH_TOKEN_LIFETIME)
             return_expiration_times = getattr(settings, 'JWT_AUTH_RETURN_EXPIRATION', False)
+            auth_httponly = getattr(settings, 'JWT_AUTH_HTTPONLY', False)
 
             data = {
                 'user': self.user,
                 'access_token': self.access_token,
-                'refresh_token': self.refresh_token,
             }
+
+            if not auth_httponly:
+                data['refresh_token'] = self.refresh_token
+            else:
+                # Wasnt sure if the serializer needed this
+                data['refresh_token'] = ""
 
             if return_expiration_times:
                 data['access_token_expiration'] = access_token_expiration


### PR DESCRIPTION
Howdy @iMerica,
Working on a project and need to get that pesky refresh token out of the body

This PR Just blanks out the `refresh_token` in the body when `JWT_AUTH_HTTPONLY=True`

Thanks!