### PR TITLE
Update with_social version specifier to allow allauth 0.50.0

### DIFF
--- a/dj_rest_auth/tests/requirements.pip
+++ b/dj_rest_auth/tests/requirements.pip
@@ -1,5 +1,5 @@
 coveralls==1.11.1
-django-allauth==0.47.0
+django-allauth==0.50.0
 djangorestframework-simplejwt==4.6.0
 flake8==3.8.4
 responses==0.12.1

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,11 @@ setup(
         'djangorestframework>=3.7.0',
     ],
     extras_require={
-        'with_social': ['django-allauth>=0.40.0,<0.48.0'],
+        'with_social': ['django-allauth>=0.40.0,<0.51.0'],
     },
     tests_require=[
         'coveralls>=1.11.1',
-        'django-allauth==0.47.0',
+        'django-allauth==0.50.0',
         'djangorestframework-simplejwt==4.6.0',
         'responses==0.12.1',
         'unittest-xml-reporting==3.0.4',


### PR DESCRIPTION
allauth was recently updated [to fix an issue with setuptools](https://github.com/pennersr/django-allauth/blob/master/ChangeLog.rst#0500-2022-03-25). This updates the `with_social` extra to allow this latest version.

Fixes #388