### PR TITLE
Fix GithubLogin class name

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -169,7 +169,7 @@ If you are using GitHub for your social authentication, it uses code and not Acc
     from allauth.socialaccount.providers.oauth2.client import OAuth2Client
     from dj_rest_auth.registration.views import SocialLoginView
 
-    class GithubLogin(SocialLoginView):
+    class GitHubLogin(SocialLoginView):
         adapter_class = GitHubOAuth2Adapter
         callback_url = CALLBACK_URL_YOU_SET_ON_GITHUB
         client_class = OAuth2Client


### PR DESCRIPTION
not matched with `path()` in urlpatterns

I think it would be better `GithubConnect` to be `GitHubConnect`, but it's not a bug.