### PR TITLE
 add package information in  optional requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ urlpatterns = [
 ```
     
 
-(Optional) Use Http-Only cookies
+(Optional) Use Http-Only cookies, Needs to install `djangorestframework-simplejwt`,
 
 ```python
 REST_USE_JWT = True


### PR DESCRIPTION
If  turn on  Http-Only cookies throws `ModuleNotFoundError: No module named 'rest_framework_simplejwt'
` , so i update readme in it to  `rest_framework_simplejwt`package.