### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -61,7 +61,7 @@ Configuration
 - **JWT_AUTH_SECURE** - If you want the cookie to be only sent to the server when a request is made with the https scheme (default: False).
 - **JWT_AUTH_HTTPONLY** - If you want to prevent client-side JavaScript from having access to the cookie (default: True).
 - **JWT_AUTH_SAMESITE** - To tell the browser not to send this cookie when performing a cross-origin request (default: 'Lax'). SameSite isn’t supported by all browsers.
-- **OLD_PASSWORD_FIELD_ENABLED** - set it to True if you want to have old password verification on password change enpoint (default: False)
+- **OLD_PASSWORD_FIELD_ENABLED** - set it to True if you want to have old password verification on password change endpoint (default: False)
 - **LOGOUT_ON_PASSWORD_CHANGE** - set to False if you want to keep the current user logged in after a password change
 - **JWT_AUTH_COOKIE_USE_CSRF** -  Enables CSRF checks for only authenticated views when using the JWT cookie for auth. Does not effect a client's ability to authenticate using a JWT Bearer Auth header without a CSRF token.
 - **JWT_AUTH_COOKIE_ENFORCE_CSRF_ON_UNAUTHENTICATED** - Enables CSRF checks for authenticated and unauthenticated views when using the JWT cookie for auth. It does not effect a client's ability to authenticate using a JWT Bearer Auth header without a CSRF token (though getting the JWT token in the first place without passing a CSRF token isnt possible).

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -285,4 +285,4 @@ This example value above will cause dj-rest-auth to return a `Set-Cookie` header
 
     Set-Cookie: my-app-auth=xxxxxxxxxxxxx; expires=Sat, 28 Mar 2020 18:59:00 GMT; HttpOnly; Max-Age=300; Path=/
 
-If ``JWT_AUTH_REFRESH_COOKIE`` is also set, it will also set a comperable cookie for that. ``JWT_AUTH_COOKIE`` is also used while authenticating each request against protected views.
+If ``JWT_AUTH_REFRESH_COOKIE`` is also set, it will also set a comparable cookie for that. ``JWT_AUTH_COOKIE`` is also used while authenticating each request against protected views.


### PR DESCRIPTION
There are small typos in:
- docs/configuration.rst
- docs/installation.rst

Fixes:
- Should read `endpoint` rather than `enpoint`.
- Should read `comparable` rather than `comperable`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md