### PR TITLE
Fix allauth email template replacing a custom one

### DIFF
--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -224,7 +224,8 @@ class PasswordResetSerializer(serializers.Serializer):
 
     @property
     def password_reset_form_class(self):
-        if 'allauth' in settings.INSTALLED_APPS:
+        custom_email_template_used = self.get_email_options().get("html_email_template_name", None) is not None
+        if 'allauth' in settings.INSTALLED_APPS and not custom_email_template_used:
             return AllAuthPasswordResetForm
         else:
             return PasswordResetForm


### PR DESCRIPTION
Hi, 

I've seen several people has run into this particular issue, where they are trying to use a custom password reset email template, but the allauth template is being used instead. For example, at #367 this exact issue was being discussed.

I don't think we need any flag. If the user is trying to use a custom html email template, avoid using the AllAuthPasswordResetForm and instead use the PasswordResetForm from Django, which will handle the custom template properly.

What do you think? Would be happy to hear some thoughts on this simple fix!

By the way, thank you for the great library