### PR TITLE
Only expect a key on E-Mail-Verification when receiving a request

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -254,7 +254,7 @@ class RegisterSerializer(serializers.Serializer):
 
 
 class VerifyEmailSerializer(serializers.Serializer):
-    key = serializers.CharField()
+    key = serializers.CharField(write_only=True)
 
 
 class ResendEmailVerificationSerializer(serializers.Serializer):


### PR DESCRIPTION
Its a minor patch, but important for us to align with open api specs. 

When DRF sends a response to a E-Mail-Verification request, it does not include the key, which is totally fine. But in this case the key should be set to write_only, which this pull request does. 

Thank you for the fork and the great work, keep on! :heart: 