### PR TITLE
Add hook for social account registration

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -172,10 +172,22 @@ class SocialLoginSerializer(serializers.Serializer):
 
             login.lookup()
             login.save(request, connect=True)
+            self.post_signup(login, attrs)
 
         attrs['user'] = login.account.user
 
         return attrs
+
+    def post_signup(self, login, attrs):
+        """
+        Inject behavior when the user signs up with a social account.
+
+        :param login: The social login instance being registered.
+        :type login: allauth.socialaccount.models.SocialLogin
+        :param attrs: The attributes of the serializer.
+        :type attrs: dict
+        """
+        pass
 
 
 class SocialConnectMixin:


### PR DESCRIPTION
## What does this pull request do?

This pull request adds a hook to the social registration serializer to inject optional custom the behavior when the user signs up with a social provider.

## Why is this useful?

I have a registration flow that requires additional information to be sent by the client so that the backend can take certain actions after the user signed up. I implemented this by subclassing the registration serializers and adding my required additional fields.

However, there currently is no clean way to run custom logic after the social account has been registered if this logic needs access to the request data. The django-allauth package does provide the `save_user` hook in the `DefaultSocialAccountAdapter`, but this hook doesn't have access to the serializer and re-parsing the request body fails in the ASGI context as the request stream has already been consumed by the serializer.

As a work-around, I currently copy the entire `validate` method into my subclass to inject my custom logic but given the amount of code that's present in the method, this isn't a long-term maintainable solution as it's very brittle to changes in the dj-rest-auth package. Adding a new lifecycle hook that fires after the registration is complete enables my use-case in a maintainable way and I can easily see this enabling many other use-cases in the future.