### PR TITLE
Up drf-yasg version in demo project to fix breaking change with removal of `NullBooleanField` from DRF

### DIFF
--- a/demo/requirements.pip
+++ b/demo/requirements.pip
@@ -1,6 +1,6 @@
 django>=2.2,<4.0
 dj-rest-auth @ git+https://github.com/iMerica/dj-rest-auth.git@master
-djangorestframework>=3.11.0
+djangorestframework>=3.11.0,<3.14.0
 djangorestframework-simplejwt==4.7.1
 django-allauth>=0.24.1
 drf-yasg==1.20.0

--- a/demo/requirements.pip
+++ b/demo/requirements.pip
@@ -1,8 +1,8 @@
 django>=2.2,<4.0
 dj-rest-auth @ git+https://github.com/iMerica/dj-rest-auth.git@master
-djangorestframework>=3.11.0,<3.14.0
+djangorestframework>=3.11.0
 djangorestframework-simplejwt==4.7.1
-django-allauth>=0.24.1
-drf-yasg==1.20.0
+django-allauth>=0.43.0
+drf-yasg==1.21.4
 django-cors-headers==3.2.1
 coreapi==2.3.3

--- a/demo/requirements.pip
+++ b/demo/requirements.pip
@@ -2,7 +2,7 @@ django>=2.2,<4.0
 dj-rest-auth @ git+https://github.com/iMerica/dj-rest-auth.git@master
 djangorestframework>=3.11.0
 djangorestframework-simplejwt==4.7.1
-django-allauth>=0.43.0
+django-allauth>=0.24.1
 drf-yasg==1.21.4
 django-cors-headers==3.2.1
 coreapi==2.3.3


### PR DESCRIPTION
`NullBooleanField` was [removed from DRF in version 3.14](https://github.com/encode/django-rest-framework/pull/8599). This broke `dry-yasg` and[ was fixed in 1.21.x](https://github.com/axnsan12/drf-yasg/pull/814). This, in turn, breaks migrations in the demo project.

This simply updates the `requirements.pip` for the demo project such that all migrations run successfully.