### PR TITLE
Fix crash on bad auth code

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -1,3 +1,4 @@
+from allauth.socialaccount.providers.oauth2.client import OAuth2Error
 from django.contrib.auth import get_user_model
 from django.core.exceptions import ValidationError as DjangoValidationError
 from django.http import HttpRequest, HttpResponseBadRequest
@@ -130,7 +131,12 @@ class SocialLoginSerializer(serializers.Serializer):
                 headers=adapter.headers,
                 basic_auth=adapter.basic_auth,
             )
-            token = client.get_access_token(code)
+            try:
+                token = client.get_access_token(code)
+            except OAuth2Error as ex:
+                raise serializers.ValidationError(
+                    _('Failed to exchange code for access token')
+                ) from ex
             access_token = token['access_token']
             tokens_to_parse = {'access_token': access_token}
 


### PR DESCRIPTION
When using the code authentication flow, a bad value currently crashes the library which leads to a HTTP 500 response bubbling up. This is inconsistent with the access token authentication flow which instead return a HTTP 400 response for a bad value.

This pull request fixes the inconsistency by returning a HTTP 400 response when the authentication code is rejected by the social provider.