### PR TITLE
RFC: support PKCE

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -38,6 +38,7 @@ class SocialAccountSerializer(serializers.ModelSerializer):
 class SocialLoginSerializer(serializers.Serializer):
     access_token = serializers.CharField(required=False, allow_blank=True)
     code = serializers.CharField(required=False, allow_blank=True)
+    code_verifier = serializers.CharField(required=False, allow_blank=True)
     id_token = serializers.CharField(required=False, allow_blank=True)
 
     def _get_request(self):
@@ -97,6 +98,7 @@ class SocialLoginSerializer(serializers.Serializer):
 
         access_token = attrs.get('access_token')
         code = attrs.get('code')
+        code_verifier = attrs.get('code_verifier')
         # Case 1: We received the access_token
         if access_token:
             tokens_to_parse = {'access_token': access_token}
@@ -130,7 +132,7 @@ class SocialLoginSerializer(serializers.Serializer):
                 headers=adapter.headers,
                 basic_auth=adapter.basic_auth,
             )
-            token = client.get_access_token(code)
+            token = client.get_access_token(code, pkce_code_verifier=code_verifier)
             access_token = token['access_token']
             tokens_to_parse = {'access_token': access_token}
 


### PR DESCRIPTION
django-allauth has implemented support for PKCE.  This RFC PR adds the necessary code_verifier field to the serializer.  I've tested it with Google, but I'd like feedback on whether this is something you'd consider merging before I spend more time on it.