### PR TITLE
Fixed AllAuthPasswordResetForm %3F in URL issue

### DIFF
--- a/dj_rest_auth/forms.py
+++ b/dj_rest_auth/forms.py
@@ -49,6 +49,8 @@ class AllAuthPasswordResetForm(DefaultPasswordResetForm):
             else:
                 url = build_absolute_uri(request, path)
 
+            url = url.replace("%3F", "?")
+
             context = {
                 'current_site': current_site,
                 'user': user,


### PR DESCRIPTION
Fixes '%3F' issue with reset password link url. Replaced '%3F' with '?'.