### PR TITLE
fix(google): Avoid id_token error after allauth upgrade

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -147,7 +147,10 @@ class SocialLoginSerializer(serializers.Serializer):
         social_token.app = app
 
         try:
-            login = self.get_social_login(adapter, app, social_token, token)
+            if adapter.provider_id == 'google':
+                login = self.get_social_login(adapter, app, social_token, response={'id_token': token})
+            else:
+                login = self.get_social_login(adapter, app, social_token, token)
             ret = complete_social_login(request, login)
         except HTTPError:
             raise serializers.ValidationError(_('Incorrect value'))


### PR DESCRIPTION
After the latest upgrade from 'allauth' package, the registration serializer is not passing the correct values to properly login with google.