### PR TITLE
Fix Google login with auth code flow

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -153,7 +153,7 @@ class SocialLoginSerializer(serializers.Serializer):
         social_token.app = app
 
         try:
-            if adapter.provider_id == 'google':
+            if adapter.provider_id == 'google' and not code:
                 login = self.get_social_login(adapter, app, social_token, response={'id_token': token})
             else:
                 login = self.get_social_login(adapter, app, social_token, token)


### PR DESCRIPTION
In https://github.com/iMerica/dj-rest-auth/pull/482 a regression was introduced for logging in with Google using the auth-code flow:

```
Traceback (most recent call last):
  File "/venv/lib/python3.11/site-packages/allauth/socialaccount/providers/google/views.py", line 21, in complete_login
    identity_data = jwt.decode(
                    ^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/jwt/api_jwt.py", line 168, in decode
    decoded = self.decode_complete(
              ^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/jwt/api_jwt.py", line 120, in decode_complete
    decoded = api_jws.decode_complete(
              ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/jwt/api_jws.py", line 191, in decode_complete
    payload, signing_input, header, signature = self._load(jwt)
                                                ^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/jwt/api_jws.py", line 247, in _load
    raise DecodeError(f"Invalid token type. Token must be a {bytes}")
jwt.exceptions.DecodeError: Invalid token type. Token must be a <class 'bytes'>

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/opt/project/backend/profiles/tests.py", line 209, in test_social_login_google
    response = self.client.post(
               ^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/test/client.py", line 852, in post
    response = super().post(
               ^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/test/client.py", line 441, in post
    return self.generic(
           ^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/test/client.py", line 541, in generic
    return self.request(**r)
           ^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/test/client.py", line 810, in request
    self.check_exception(response)
  File "/venv/lib/python3.11/site-packages/django/test/client.py", line 663, in check_exception
    raise exc_value
  File "/venv/lib/python3.11/site-packages/django/core/handlers/exception.py", line 56, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/views/decorators/csrf.py", line 55, in wrapped_view
    return view_func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/django/views/generic/base.py", line 103, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/rest_framework/views.py", line 509, in dispatch
    response = self.handle_exception(exc)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/rest_framework/views.py", line 469, in handle_exception
    self.raise_uncaught_exception(exc)
  File "/venv/lib/python3.11/site-packages/rest_framework/views.py", line 480, in raise_uncaught_exception
    raise exc
  File "/venv/lib/python3.11/site-packages/rest_framework/views.py", line 506, in dispatch
    response = handler(request, *args, **kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/project/backend/profiles/views.py", line 147, in post
    serializer.is_valid(raise_exception=True)
  File "/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 227, in is_valid
    self._validated_data = self.run_validation(self.initial_data)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/rest_framework/serializers.py", line 429, in run_validation
    value = self.validate(value)
            ^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/dj_rest_auth/registration/serializers.py", line 151, in validate
    login = self.get_social_login(adapter, app, social_token, response={'id_token': token})
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/dj_rest_auth/registration/serializers.py", line 60, in get_social_login
    social_login = adapter.complete_login(request, app, token, response=response)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/venv/lib/python3.11/site-packages/allauth/socialaccount/providers/google/views.py", line 39, in complete_login
    raise OAuth2Error("Invalid id_token") from e
allauth.socialaccount.providers.oauth2.client.OAuth2Error: Invalid id_token
```

For the latest allauth, in the auth-code flow, the `token` variable already holds a dictionary with an `id_token` field so it's unnecessary to wrap the response. This pull request fixes the regression.