### PR TITLE
Modify JWT Serializer Field Names

### DIFF
--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -96,7 +96,7 @@ def get_refresh_view():
         def finalize_response(self, request, response, *args, **kwargs):
             if response.status_code == status.HTTP_200_OK and 'access' in response.data:
                 set_jwt_access_cookie(response, response.data['access'])
-                response.data['access_token_expiration'] = (timezone.now() + jwt_settings.ACCESS_TOKEN_LIFETIME)
+                response.data['access_expiration'] = (timezone.now() + jwt_settings.ACCESS_TOKEN_LIFETIME)
             if response.status_code == status.HTTP_200_OK and 'refresh' in response.data:
                 set_jwt_refresh_cookie(response, response.data['refresh'])
             return super().finalize_response(request, response, *args, **kwargs)

--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -99,6 +99,7 @@ def get_refresh_view():
                 response.data['access_expiration'] = (timezone.now() + jwt_settings.ACCESS_TOKEN_LIFETIME)
             if response.status_code == status.HTTP_200_OK and 'refresh' in response.data:
                 set_jwt_refresh_cookie(response, response.data['refresh'])
+                response.data['refresh_expiration'] = (timezone.now() + jwt_settings.REFRESH_TOKEN_LIFETIME)
             return super().finalize_response(request, response, *args, **kwargs)
     return RefreshViewWithCookieSupport
 

--- a/dj_rest_auth/registration/views.py
+++ b/dj_rest_auth/registration/views.py
@@ -49,8 +49,8 @@ class RegisterView(CreateAPIView):
         if api_settings.USE_JWT:
             data = {
                 'user': user,
-                'access_token': self.access_token,
-                'refresh_token': self.refresh_token,
+                'access': self.access_token,
+                'refresh': self.refresh_token,
             }
             return api_settings.JWT_SERIALIZER(data, context=self.get_serializer_context()).data
         elif api_settings.SESSION_LOGIN:

--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -185,8 +185,8 @@ class JWTSerializer(serializers.Serializer):
     """
     Serializer for JWT authentication.
     """
-    access_token = serializers.CharField()
-    refresh_token = serializers.CharField()
+    access = serializers.CharField()
+    refresh = serializers.CharField()
     user = serializers.SerializerMethodField()
 
     def get_user(self, obj):
@@ -204,8 +204,8 @@ class JWTSerializerWithExpiration(JWTSerializer):
     """
     Serializer for JWT authentication with expiration times.
     """
-    access_token_expiration = serializers.DateTimeField()
-    refresh_token_expiration = serializers.DateTimeField()
+    access_expiration = serializers.DateTimeField()
+    refresh_expiration = serializers.DateTimeField()
 
 
 class PasswordResetSerializer(serializers.Serializer):

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -182,8 +182,8 @@ class APIBasicTests(TestsMixin, TestCase):
         get_user_model().objects.create_user(self.USERNAME, '', self.PASS)
 
         self.post(self.login_url, data=payload, status_code=200)
-        self.assertEqual('access_token' in self.response.json.keys(), True)
-        self.token = self.response.json['access_token']
+        self.assertEqual('access' in self.response.json.keys(), True)
+        self.token = self.response.json['access']
 
     @modify_settings(INSTALLED_APPS={'remove': ['allauth', 'allauth.account']})
     def test_login_by_email(self):
@@ -278,7 +278,7 @@ class APIBasicTests(TestsMixin, TestCase):
         self.token = self.response.json['key']
         new_password_payload = {"new_password1": 123, "new_password2": 123}
         self.post(self.password_change_url, data=new_password_payload, status_code=400)
-    
+
     @override_api_settings(OLD_PASSWORD_FIELD_ENABLED=True)
     def test_password_change_with_old_password(self):
         login_payload = {
@@ -439,7 +439,7 @@ class APIBasicTests(TestsMixin, TestCase):
             'password': self.PASS,
         }
         self.post(self.login_url, data=payload, status_code=200)
-        self.token = self.response.json['access_token']
+        self.token = self.response.json['access']
         self.get(self.user_url, status_code=200)
 
         self.patch(self.user_url, data=self.BASIC_USER_DATA, status_code=200)
@@ -522,7 +522,7 @@ class APIBasicTests(TestsMixin, TestCase):
         self.post(self.register_url, data={}, status_code=400)
 
         result = self.post(self.register_url, data=self.REGISTRATION_DATA, status_code=201)
-        self.assertIn('access_token', result.data)
+        self.assertIn('access', result.data)
         self.assertEqual(get_user_model().objects.all().count(), user_count + 1)
 
         self._login()
@@ -727,7 +727,7 @@ class APIBasicTests(TestsMixin, TestCase):
         }
         get_user_model().objects.create_user(self.USERNAME, '', self.PASS)
         resp = self.post(self.login_url, data=payload, status_code=200)
-        token = resp.data['refresh_token']
+        token = resp.data['refresh']
         resp = self.post(self.logout_url, status=200, data={'refresh': token})
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(
@@ -745,7 +745,7 @@ class APIBasicTests(TestsMixin, TestCase):
         }
         get_user_model().objects.create_user(self.USERNAME, '', self.PASS)
         resp = self.post(self.login_url, data=payload, status_code=200)
-        token = resp.data['refresh_token']
+        token = resp.data['refresh']
         # test refresh token not included in request data
         self.post(self.logout_url, status_code=401)
         # test token is invalid or expired
@@ -776,8 +776,8 @@ class APIBasicTests(TestsMixin, TestCase):
         get_user_model().objects.create_user(self.USERNAME, self.EMAIL, self.PASS)
 
         self.post(self.login_url, data=payload, status_code=200)
-        self.assertEqual('access_token' in self.response.json.keys(), True)
-        self.token = self.response.json['access_token']
+        self.assertEqual('access' in self.response.json.keys(), True)
+        self.token = self.response.json['access']
         claims = decode_jwt(self.token, settings.SECRET_KEY, algorithms='HS256')
         self.assertEquals(claims['user_id'], 1)
         self.assertEquals(claims['name'], 'person')
@@ -839,7 +839,7 @@ class APIBasicTests(TestsMixin, TestCase):
 
         ## TEST WITH JWT AUTH HEADER
         jwtclient = APIClient(enforce_csrf_checks=True)
-        token = resp.data['access_token']
+        token = resp.data['access']
         resp = jwtclient.get('/protected-view/', HTTP_AUTHORIZATION='Bearer ' + token)
         self.assertEquals(resp.status_code, 200)
         resp = jwtclient.post('/protected-view/', {}, HTTP_AUTHORIZATION='Bearer ' + token)
@@ -885,7 +885,7 @@ class APIBasicTests(TestsMixin, TestCase):
 
         ## TEST WITH JWT AUTH HEADER
         jwtclient = APIClient(enforce_csrf_checks=True)
-        token = resp.data['access_token']
+        token = resp.data['access']
         resp = jwtclient.get('/protected-view/')
         self.assertEquals(resp.status_code, 403)
         resp = jwtclient.get('/protected-view/', HTTP_AUTHORIZATION='Bearer ' + token)
@@ -1017,8 +1017,8 @@ class APIBasicTests(TestsMixin, TestCase):
         get_user_model().objects.create_user(self.USERNAME, '', self.PASS)
 
         resp = self.post(self.login_url, data=payload, status_code=200)
-        self.assertIn('access_token_expiration', resp.data.keys())
-        self.assertIn('refresh_token_expiration', resp.data.keys())
+        self.assertIn('access_expiration', resp.data.keys())
+        self.assertIn('refresh_expiration', resp.data.keys())
 
     @override_api_settings(JWT_AUTH_RETURN_EXPIRATION=True)
     @override_api_settings(USE_JWT=True)
@@ -1053,7 +1053,7 @@ class APIBasicTests(TestsMixin, TestCase):
 
         get_user_model().objects.create_user(self.USERNAME, '', self.PASS)
         resp = self.post(self.login_url, data=payload, status_code=200)
-        refresh = resp.data.get('refresh_token')
+        refresh = resp.data.get('refresh')
         refresh_resp = self.post(
             reverse('token_refresh'),
             data=dict(refresh=refresh),
@@ -1075,7 +1075,7 @@ class APIBasicTests(TestsMixin, TestCase):
         resp = self.post(self.login_url, data=payload)
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
 
-        refresh = resp.data.get('refresh_token', None)
+        refresh = resp.data.get('refresh', None)
         resp = self.post(
             reverse('token_refresh'),
             data=dict(refresh=refresh),

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -1061,6 +1061,10 @@ class APIBasicTests(TestsMixin, TestCase):
         )
         self.assertIn('xxx', refresh_resp.cookies)
 
+        # Ensure access keys are provided in response
+        self.assertIn('access', refresh_resp.data)
+        self.assertIn('access_expiration', refresh_resp.data)
+
     @override_api_settings(USE_JWT=True)
     @override_api_settings(JWT_AUTH_HTTPONLY=False)
     def test_rotate_token_refresh_view(self):
@@ -1081,7 +1085,10 @@ class APIBasicTests(TestsMixin, TestCase):
             data=dict(refresh=refresh),
         )
         self.assertEqual(resp.status_code, status.HTTP_200_OK)
+
+        # Ensure access keys are provided in response
         self.assertIn('refresh', resp.data)
+        self.assertIn('refresh_expiration', resp.data)
 
     @override_api_settings(TOKEN_MODEL=None)
     @modify_settings(INSTALLED_APPS={'remove': ['rest_framework.authtoken']})

--- a/dj_rest_auth/tests/test_social.py
+++ b/dj_rest_auth/tests/test_social.py
@@ -303,7 +303,7 @@ class TestSocialAuth(TestsMixin, TestCase):
         }
 
         self.post(self.fb_login_url, data=payload, status_code=200)
-        self.assertIn('access_token', self.response.json.keys())
+        self.assertIn('access', self.response.json.keys())
         self.assertIn('user', self.response.json.keys())
 
         self.assertEqual(get_user_model().objects.all().count(), users_count + 1)

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -88,18 +88,18 @@ class LoginView(GenericAPIView):
 
             data = {
                 'user': self.user,
-                'access_token': self.access_token,
+                'access': self.access_token,
             }
 
             if not auth_httponly:
-                data['refresh_token'] = self.refresh_token
+                data['refresh'] = self.refresh_token
             else:
                 # Wasnt sure if the serializer needed this
-                data['refresh_token'] = ""
+                data['refresh'] = ""
 
             if return_expiration_times:
-                data['access_token_expiration'] = access_token_expiration
-                data['refresh_token_expiration'] = refresh_token_expiration
+                data['access_expiration'] = access_token_expiration
+                data['refresh_expiration'] = refresh_token_expiration
 
             serializer = serializer_class(
                 instance=data,


### PR DESCRIPTION
Closes #142 

This change modifies the `JWTSerializer` fields to be `access` and `response` to align with the naming of [rest_framework_jwt.serializers.TokenRefreshSerializer](https://github.com/jazzband/djangorestframework-simplejwt/blob/master/rest_framework_simplejwt/serializers.py#L102)

With `rest_framework_simplejwt` being tightly coupled into the JWT usage, this made sense to adhere to the upstream dependency naming standards.

Ultimately, it's ugly when using JWT to check for `access_token` names when authenticating, and then using `access` for a refresh.