### PR TITLE
Support custom verification status based on email

### DIFF
--- a/dj_rest_auth/serializers.py
+++ b/dj_rest_auth/serializers.py
@@ -107,7 +107,7 @@ class LoginSerializer(serializers.Serializer):
             raise exceptions.ValidationError(msg)
 
     @staticmethod
-    def validate_email_verification_status(user):
+    def validate_email_verification_status(user, email=None):
         from allauth.account import app_settings as allauth_account_settings
         if (
             allauth_account_settings.EMAIL_VERIFICATION == allauth_account_settings.EmailVerificationMethod.MANDATORY
@@ -130,7 +130,7 @@ class LoginSerializer(serializers.Serializer):
 
         # If required, is the email verified?
         if 'dj_rest_auth.registration' in settings.INSTALLED_APPS:
-            self.validate_email_verification_status(user)
+            self.validate_email_verification_status(user, email=email)
 
         attrs['user'] = user
         return attrs


### PR DESCRIPTION
## What does this change do?

This pull request extends the interface of `LoginSerializer.validate_email_verification_status` to pass-through the email value that's used for the current login. This interface change enables us to customize the logic to check the verification status in subclasses without needing to override the full `validate` method, thus reducing coupling between subclasses and the parent.

## Why is this useful?

I'm working on a system where the user is allowed to change their email but they need to verify their new email before they can use it to log in. Currently, dj-rest-auth will allow the user to log in with their new email address even before it's verified as the code is checking that the user has *any* verified email address. I want to customize this behavior by subclassing to check that the specific email address the user is logging in with is verified:

```py
class MyLoginSerializer(LoginSerializer):
    @staticmethod
    def validate_email_verification_status(user, email=None):
        if not user.emailaddress_set.filter(email=email, verified=True).exists():
            raise serializers.ValidationError(_('E-mail is not verified.'))
```

Arguably dj-rest-auth could even make this check the default behavior as it seems semantically correct, but this would be a backwards incompatible change which is why I propose the change in this PR to simply extend the interface of the validation function.