### PR TITLE
Bump django-allauth (#506)

### DIFF
--- a/dj_rest_auth/tests/requirements.pip
+++ b/dj_rest_auth/tests/requirements.pip
@@ -1,5 +1,5 @@
 coveralls==1.11.1
-django-allauth==0.52.0
+django-allauth==0.54.0
 djangorestframework-simplejwt==4.6.0
 flake8==3.8.4
 responses==0.12.1

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,11 @@ setup(
         'djangorestframework>=3.7.0',
     ],
     extras_require={
-        'with_social': ['django-allauth>=0.40.0,<0.53.0'],
+        'with_social': ['django-allauth>=0.40.0,<0.55.0'],
     },
     tests_require=[
         'coveralls>=1.11.1',
-        'django-allauth==0.52.0',
+        'django-allauth==0.54.0',
         'djangorestframework-simplejwt==4.6.0',
         'responses==0.12.1',
         'unittest-xml-reporting==3.0.4',


### PR DESCRIPTION
Bumping django-allauth from 0.52.0 to 0.54.0 fixes vulnerability issue reported here: https://pyup.io/v/54809/f17/

This fixes the issue #506 