### PR TITLE
Add Microsoft Graph Login Option to Social Serializers

### DIFF
--- a/dj_rest_auth/social_serializers.py
+++ b/dj_rest_auth/social_serializers.py
@@ -10,7 +10,7 @@ if 'allauth.socialaccount' in settings.INSTALLED_APPS:
     from allauth.socialaccount.models import SocialToken
     from allauth.socialaccount.providers.oauth.client import OAuthError
 
-    from dj_rest_auth.registration.serializers import SocialConnectMixin, SocialLoginSerializer
+    from dj_rest_auth.registration.serializers import SocialConnectMixin
 
 
 class TwitterLoginSerializer(serializers.Serializer):


### PR DESCRIPTION
This adds the MicrosoftLoginSerializer in `social_serializers.py`. It works the same way as TwitterLoginSerializer, except the key for 'access_token' is changed to 'accessToken' and the secret is not needed.