### PR TITLE
Fixed Incompatibility with django-allauth v0.55.0

### DIFF
--- a/demo/requirements.pip
+++ b/demo/requirements.pip
@@ -1,8 +1,8 @@
-django==4.2.4
+django>=2.2,<4.0
 dj-rest-auth @ git+https://github.com/brandon-kong/dj-rest-auth.git@master
 djangorestframework>=3.11.0
 djangorestframework-simplejwt==4.7.1
-django-allauth>=0.55.0
+django-allauth>=0.24.1
 drf-yasg==1.21.4
 django-cors-headers==3.2.1
 coreapi==2.3.3

--- a/demo/requirements.pip
+++ b/demo/requirements.pip
@@ -1,8 +1,8 @@
-django>=2.2,<4.0
-dj-rest-auth @ git+https://github.com/iMerica/dj-rest-auth.git@master
+django==4.2.4
+dj-rest-auth @ git+https://github.com/brandon-kong/dj-rest-auth.git@master
 djangorestframework>=3.11.0
 djangorestframework-simplejwt==4.7.1
-django-allauth>=0.24.1
+django-allauth>=0.55.0
 drf-yasg==1.21.4
 django-cors-headers==3.2.1
 coreapi==2.3.3

--- a/demo/requirements.pip
+++ b/demo/requirements.pip
@@ -2,7 +2,7 @@ django>=2.2,<4.0
 dj-rest-auth @ git+https://github.com/brandon-kong/dj-rest-auth.git@master
 djangorestframework>=3.11.0
 djangorestframework-simplejwt==4.7.1
-django-allauth>=0.24.1
+django-allauth>=0.55.0
 drf-yasg==1.21.4
 django-cors-headers==3.2.1
 coreapi==2.3.3

--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -17,6 +17,7 @@ try:
     from allauth.socialaccount.models import SocialAccount
     from allauth.socialaccount.providers.base import AuthProcess
     from allauth.utils import get_username_max_length
+    from allauth.account.models import EmailAddress
 except ImportError:
     raise ImportError('allauth needs to be added to INSTALLED_APPS.')
 
@@ -233,7 +234,7 @@ class RegisterSerializer(serializers.Serializer):
     def validate_email(self, email):
         email = get_adapter().clean_email(email)
         if allauth_account_settings.UNIQUE_EMAIL:
-            if email and email_address_exists(email):
+            if email and EmailAddress.objects.is_verified(email):
                 raise serializers.ValidationError(
                     _('A user is already registered with this e-mail address.'),
                 )

--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -7,6 +7,7 @@ from django.utils.translation import gettext_lazy as _
 from requests.exceptions import HTTPError
 from rest_framework import serializers
 from rest_framework.reverse import reverse
+from dj_rest_auth.utils import email_address_exists
 
 try:
     from allauth.account import app_settings as allauth_account_settings
@@ -15,7 +16,7 @@ try:
     from allauth.socialaccount.helpers import complete_social_login
     from allauth.socialaccount.models import SocialAccount
     from allauth.socialaccount.providers.base import AuthProcess
-    from allauth.utils import email_address_exists, get_username_max_length
+    from allauth.utils import get_username_max_length
 except ImportError:
     raise ImportError('allauth needs to be added to INSTALLED_APPS.')
 

--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -17,7 +17,6 @@ try:
     from allauth.socialaccount.models import SocialAccount
     from allauth.socialaccount.providers.base import AuthProcess
     from allauth.utils import get_username_max_length
-    from allauth.account.models import EmailAddress
 except ImportError:
     raise ImportError('allauth needs to be added to INSTALLED_APPS.')
 
@@ -234,7 +233,7 @@ class RegisterSerializer(serializers.Serializer):
     def validate_email(self, email):
         email = get_adapter().clean_email(email)
         if allauth_account_settings.UNIQUE_EMAIL:
-            if email and EmailAddress.objects.is_verified(email):
+            if email and email_address_exists(email):
                 raise serializers.ValidationError(
                     _('A user is already registered with this e-mail address.'),
                 )

--- a/dj_rest_auth/utils.py
+++ b/dj_rest_auth/utils.py
@@ -1,4 +1,13 @@
 from django.utils.functional import lazy
+from allauth.account.models import EmailAddress
+
+def email_address_exists(email: str) -> bool:
+    """Check if an email address exists in the EmailAddress table."""
+    try:
+        EmailAddress.objects.get(email=email)
+    except EmailAddress.DoesNotExist:
+        return False
+    return True
 
 
 def default_create_token(token_model, user, serializer):


### PR DESCRIPTION
dj-rest-auth is not compatible with django-allauth's latest version. This PR fixes that issue upon the newest release of django-allauth v0.55.0.

I created a `email_address_exists` method in dj_rest_auth's utils with the same implementation.

- Closes issue #534 