### PR TITLE
fix: drop use of deprecated allauth.utils.email_address_exists function

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -13,9 +13,9 @@ try:
     from allauth.account.adapter import get_adapter
     from allauth.account.utils import setup_user_email
     from allauth.socialaccount.helpers import complete_social_login
-    from allauth.socialaccount.models import SocialAccount
+    from allauth.socialaccount.models import EmailAddress, SocialAccount
     from allauth.socialaccount.providers.base import AuthProcess
-    from allauth.utils import email_address_exists, get_username_max_length
+    from allauth.utils import get_username_max_length
 except ImportError:
     raise ImportError('allauth needs to be added to INSTALLED_APPS.')
 
@@ -232,7 +232,7 @@ class RegisterSerializer(serializers.Serializer):
     def validate_email(self, email):
         email = get_adapter().clean_email(email)
         if allauth_account_settings.UNIQUE_EMAIL:
-            if email and email_address_exists(email):
+            if email and EmailAddress.objects.is_verified(email):
                 raise serializers.ValidationError(
                     _('A user is already registered with this e-mail address.'),
                 )


### PR DESCRIPTION
`allauth.utils.email_address_exists` was removed recently, see
https://github.com/pennersr/django-allauth/blob/main/ChangeLog.rst#0550-2023-08-22