### PR TITLE
Added key and uid fields to the reset password form

### DIFF
--- a/dj_rest_auth/forms.py
+++ b/dj_rest_auth/forms.py
@@ -62,12 +62,15 @@ class AllAuthPasswordResetForm(DefaultPasswordResetForm):
             # send the password reset email
             url_generator = kwargs.get('url_generator', default_url_generator)
             url = url_generator(request, user, temp_key)
+            uid = user.id
 
             context = {
                 'current_site': current_site,
                 'user': user,
                 'password_reset_url': url,
                 'request': request,
+                'key': temp_key,
+                'uid': uid,
             }
             if (
                 allauth_account_settings.AUTHENTICATION_METHOD

--- a/dj_rest_auth/forms.py
+++ b/dj_rest_auth/forms.py
@@ -69,7 +69,7 @@ class AllAuthPasswordResetForm(DefaultPasswordResetForm):
                 'user': user,
                 'password_reset_url': url,
                 'request': request,
-                'key': temp_key,
+                'token': temp_key,
                 'uid': uid,
             }
             if (

--- a/dj_rest_auth/forms.py
+++ b/dj_rest_auth/forms.py
@@ -62,7 +62,7 @@ class AllAuthPasswordResetForm(DefaultPasswordResetForm):
             # send the password reset email
             url_generator = kwargs.get('url_generator', default_url_generator)
             url = url_generator(request, user, temp_key)
-            uid = user.id
+            uid = user_pk_to_url_str(user)
 
             context = {
                 'current_site': current_site,


### PR DESCRIPTION
This PR adds the `key` and `uid` fields to the Context of `AllAuthPasswordResetForm`. This is done to have consistency with the Django Admin `templates/registration/password_reset_email.html` regarding available template variables.

Looking forward to your input