### PR TITLE
Install allacccount middleware in test settings

### DIFF
--- a/dj_rest_auth/tests/requirements.pip
+++ b/dj_rest_auth/tests/requirements.pip
@@ -1,5 +1,5 @@
 coveralls==1.11.1
-django-allauth==0.55.2
+django-allauth==0.57.0
 djangorestframework-simplejwt==4.6.0
 flake8==3.8.4
 responses==0.12.1

--- a/dj_rest_auth/tests/settings.py
+++ b/dj_rest_auth/tests/settings.py
@@ -35,6 +35,7 @@ MIDDLEWARE = [
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
+    'allauth.account.middleware.AccountMiddleware',
 ]
 
 # Adding for backwards compatibility for Django 1.8 tests

--- a/setup.py
+++ b/setup.py
@@ -32,11 +32,11 @@ setup(
         'djangorestframework>=3.13.0',
     ],
     extras_require={
-        'with_social': ['django-allauth>=0.55.0,<0.56.0'],
+        'with_social': ['django-allauth>=0.56.0,<0.58.0'],
     },
     tests_require=[
         'coveralls>=1.11.1',
-        'django-allauth==0.55.2',
+        'django-allauth>=0.57.0',
         'djangorestframework-simplejwt==4.6.0',
         'responses==0.12.1',
         'unittest-xml-reporting==3.0.4',


### PR DESCRIPTION
This fixes the test suite for me.

Bumps the requirement for allauth, since the middleware is only shipped from 0.56.0

Closes: #555