### PR TITLE
fix: Fixes issue with JWTStatelessUserAuthentication

### DIFF
--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -12,6 +12,7 @@ from rest_framework.generics import GenericAPIView, RetrieveUpdateAPIView
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework_simplejwt.models import TokenUser
 
 from .app_settings import api_settings
 from .models import get_token_model
@@ -231,6 +232,8 @@ class UserDetailsView(RetrieveUpdateAPIView):
     permission_classes = (IsAuthenticated,)
 
     def get_object(self):
+        if isinstance(self.request.user, TokenUser):
+            return get_user_model().objects.get(id=self.request.user.id)
         return self.request.user
 
     def get_queryset(self):


### PR DESCRIPTION
The JWTStatelessUserAuthentication backend’s authenticate method does not perform a database lookup to obtain a user instance.

Instead, it returns a rest_framework_simplejwt.models.TokenUser instance which acts as a stateless user object backed only by a validated token instead of a record in a database.

This is not taken into account in the user and password endpoints of dj-rest-auth causing either incomplete information to be returned for the user or, in the worst case, a full crash due to invocation of methods that are not implemented for TokenUser.

This PR fixes it by checking whether the current user is a TokenUser and fetching the proper User before applying any changes.