### PR TITLE
Add missing allauth middleware to demo settings.py

### DIFF
--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -54,6 +54,7 @@ MIDDLEWARE = (
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+    'allauth.account.middleware.AccountMiddleware'
 )
 
 # For backwards compatibility for Django 1.8


### PR DESCRIPTION
When I tried running `python manage.py migrate --settings=demo.settings --noinput` I got the following exception:
```bash 
django.core.exceptions.ImproperlyConfigured: allauth.account.middleware.AccountMiddleware must be added to settings.MIDDLEWARE
```
Adding `allauth.account.middleware.AccountMiddleware` to settings.py fixes this and the migrations apply correctly.