### PR TITLE
[Security] Remove tokens from response body if httpOnly Cookie and Rotate Refresh token is being Used

### DIFF
--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -101,13 +101,10 @@ def get_refresh_view():
 
         def finalize_response(self, request, response, *args, **kwargs):
             if response.status_code == status.HTTP_200_OK and 'access' in response.data:
-                if api_settings.JWT_AUTH_COOKIE:
-                    set_jwt_access_cookie(response, response.data['access'])
-                    del response.data['access']
-                else:
-                    response.data['access_expiration'] = (timezone.now() + jwt_settings.ACCESS_TOKEN_LIFETIME)
+                set_jwt_access_cookie(response, response.data['access'])
+                response.data['access_expiration'] = (timezone.now() + jwt_settings.ACCESS_TOKEN_LIFETIME)
             if response.status_code == status.HTTP_200_OK and 'refresh' in response.data:
-                if api_settings.JWT_AUTH_REFRESH_COOKIE:
+                if api_settings.JWT_AUTH_REFRESH_COOKIE and api_settings.JWT_AUTH_HTTPONLY:
                     set_jwt_refresh_cookie(response, response.data['refresh'])
                     del response.data['refresh']
                 else:

--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -104,8 +104,8 @@ def get_refresh_view():
                 set_jwt_access_cookie(response, response.data['access'])
                 response.data['access_expiration'] = (timezone.now() + jwt_settings.ACCESS_TOKEN_LIFETIME)
             if response.status_code == status.HTTP_200_OK and 'refresh' in response.data:
-                if api_settings.JWT_AUTH_REFRESH_COOKIE and api_settings.JWT_AUTH_HTTPONLY:
-                    set_jwt_refresh_cookie(response, response.data['refresh'])
+                set_jwt_refresh_cookie(response, response.data['refresh'])
+                if api_settings.JWT_AUTH_HTTPONLY:
                     del response.data['refresh']
                 else:
                     response.data['refresh_expiration'] = (timezone.now() + jwt_settings.REFRESH_TOKEN_LIFETIME)

--- a/dj_rest_auth/jwt_auth.py
+++ b/dj_rest_auth/jwt_auth.py
@@ -101,11 +101,17 @@ def get_refresh_view():
 
         def finalize_response(self, request, response, *args, **kwargs):
             if response.status_code == status.HTTP_200_OK and 'access' in response.data:
-                set_jwt_access_cookie(response, response.data['access'])
-                response.data['access_expiration'] = (timezone.now() + jwt_settings.ACCESS_TOKEN_LIFETIME)
+                if api_settings.JWT_AUTH_COOKIE:
+                    set_jwt_access_cookie(response, response.data['access'])
+                    del response.data['access']
+                else:
+                    response.data['access_expiration'] = (timezone.now() + jwt_settings.ACCESS_TOKEN_LIFETIME)
             if response.status_code == status.HTTP_200_OK and 'refresh' in response.data:
-                set_jwt_refresh_cookie(response, response.data['refresh'])
-                response.data['refresh_expiration'] = (timezone.now() + jwt_settings.REFRESH_TOKEN_LIFETIME)
+                if api_settings.JWT_AUTH_REFRESH_COOKIE:
+                    set_jwt_refresh_cookie(response, response.data['refresh'])
+                    del response.data['refresh']
+                else:
+                    response.data['refresh_expiration'] = (timezone.now() + jwt_settings.REFRESH_TOKEN_LIFETIME)
             return super().finalize_response(request, response, *args, **kwargs)
     return RefreshViewWithCookieSupport
 


### PR DESCRIPTION
The reason for using cookies over Bearer token in headers is because the javascript code can't access http only cookies.

Currently I see, even if we are using cookies for authentication, we are not removing the tokens from response body.
For now, I have only made this change for refresh token and not changed anything related to access token to be consistent with LoginView. But I believe we should remove the access token as well if we are using http only cookies.