### PR TITLE
fix: broken demo - add allauth to middleware 

### DIFF
--- a/demo/demo/settings.py
+++ b/demo/demo/settings.py
@@ -47,6 +47,7 @@ INSTALLED_APPS = (
 )
 
 MIDDLEWARE = (
+    'allauth.account.middleware.AccountMiddleware',
     'corsheaders.middleware.CorsMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
when the [demo](https://dj-rest-auth.readthedocs.io/en/latest/demo.html) is run using `python manage.py migrate --settings=demo.settings --noinput` , the following exception is thrown:

```
django.core.exceptions.ImproperlyConfigured: allauth.account.middleware.AccountMiddleware must be added to settings.MIDDLEWARE
```


This PR adds `allauth.account.middleware.AccountMiddleware` to `settings.py`
