### PR TITLE
Disable email confirmation ratelimit in tests to support new allauth

### DIFF
--- a/dj_rest_auth/tests/requirements.pip
+++ b/dj_rest_auth/tests/requirements.pip
@@ -1,5 +1,6 @@
 coveralls==1.11.1
-django-allauth==0.57.0
+django-allauth==0.61.1
+django>=2.2,<5.0
 djangorestframework-simplejwt==4.6.0
 flake8==3.8.4
 responses==0.12.1

--- a/dj_rest_auth/tests/settings.py
+++ b/dj_rest_auth/tests/settings.py
@@ -98,6 +98,10 @@ INSTALLED_APPS = [
 
 SECRET_KEY = '38dh*skf8sjfhs287dh&^hd8&3hdg*j2&sd'
 ACCOUNT_ACTIVATION_DAYS = 1
+# With the default rate limits of allauth only one email confirmation per 180s is supported
+ACCOUNT_RATE_LIMITS = {
+    'confirm_email': None
+}
 SITE_ID = 1
 
 AUTHENTICATION_BACKENDS = (

--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,11 @@ setup(
     keywords='django rest auth registration rest-framework django-registration api',
     zip_safe=False,
     install_requires=[
-        'Django>=3.2',
+        'Django>=3.2,<5.0',
         'djangorestframework>=3.13.0',
     ],
     extras_require={
-        'with_social': ['django-allauth>=0.56.0,<0.58.0'],
+        'with_social': ['django-allauth>=0.56.0,<0.62.0'],
     },
     tests_require=[
         'coveralls>=1.11.1',


### PR DESCRIPTION
allauth introduced a [very restrictive rate limit](https://github.com/pennersr/django-allauth/commit/349f6dedee239bee3909e144b29cfab194d3648b#diff-2f582c056d722827d28d46237f67cbbf4885564ee307be4bd86215886be55ce9R220) of 1 email confirmation per 180s in v0.61.0. This doesn't work in the tests.

As we want to support newer allauth versions, simply disable the ratelimit in the tests.