### PR TITLE
Added a request.auth check to logout to avoid false success message when no token is passed

### DIFF
--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -150,6 +150,11 @@ class LogoutView(APIView):
         return self.logout(request)
 
     def logout(self, request):
+        if not request.auth:
+            return Response(
+                {'detail': _('You should be logged in to logout. Check whether the token is passed.')},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
         try:
             request.user.auth_token.delete()
         except (AttributeError, ObjectDoesNotExist):

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -150,7 +150,7 @@ class LogoutView(APIView):
         return self.logout(request)
 
     def logout(self, request):
-        if not request.auth:
+        if not (request.auth or api_settings.USE_JWT or api_settings.SESSION_LOGIN):
             return Response(
                 {'detail': _('You should be logged in to logout. Check whether the token is passed.')},
                 status=status.HTTP_400_BAD_REQUEST,


### PR DESCRIPTION
In case of no authentication token is passed it results a fake successful message in logout. Added a check to request.auth on top of logout

Before the change, the auth_token.delete() undergoes to AnonymousUser which will not affect the current user. But it sends the success message disguising the developer. 