### PR TITLE
Fix creating user token during the registration process when both Token authentication and Session authentication are used simultaneously

### DIFF
--- a/dj_rest_auth/registration/views.py
+++ b/dj_rest_auth/registration/views.py
@@ -53,10 +53,10 @@ class RegisterView(CreateAPIView):
                 'refresh': self.refresh_token,
             }
             return api_settings.JWT_SERIALIZER(data, context=self.get_serializer_context()).data
-        elif api_settings.SESSION_LOGIN:
-            return None
-        else:
+        elif self.token_model:
             return api_settings.TOKEN_SERIALIZER(user.auth_token, context=self.get_serializer_context()).data
+        
+        return None
 
     def create(self, request, *args, **kwargs):
         serializer = self.get_serializer(data=request.data)
@@ -82,9 +82,7 @@ class RegisterView(CreateAPIView):
                 allauth_account_settings.EmailVerificationMethod.MANDATORY:
             if api_settings.USE_JWT:
                 self.access_token, self.refresh_token = jwt_encode(user)
-            elif not api_settings.SESSION_LOGIN:
-                # Session authentication isn't active either, so this has to be
-                #  token authentication
+            elif self.token_model:
                 api_settings.TOKEN_CREATOR(self.token_model, user, serializer)
 
         complete_signup(

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -531,12 +531,28 @@ class APIBasicTests(TestsMixin, TestCase):
     @override_api_settings(SESSION_LOGIN=True)
     @override_api_settings(TOKEN_MODEL=None)
     def test_registration_with_session(self):
+        import sys
+        from importlib import reload
+        from django.contrib.sessions.middleware import SessionMiddleware
+        from django.contrib.messages.middleware import MessageMiddleware
+        reload(sys.modules['dj_rest_auth.models'])
+        reload(sys.modules['dj_rest_auth.registration.views'])
+        from dj_rest_auth.registration.views import RegisterView
+
         user_count = get_user_model().objects.all().count()
 
         self.post(self.register_url, data={}, status_code=400)
 
-        result = self.post(self.register_url, data=self.REGISTRATION_DATA, status_code=204)
-        self.assertEqual(result.data, None)
+        factory = APIRequestFactory()
+        request = factory.post(self.register_url, self.REGISTRATION_DATA)
+
+        for middleware_class in (SessionMiddleware, MessageMiddleware):
+            middleware = middleware_class(lambda request: None)
+            middleware.process_request(request)
+
+        response = RegisterView.as_view()(request)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.data, None)
         self.assertEqual(get_user_model().objects.all().count(), user_count + 1)
 
         self._login(status.HTTP_204_NO_CONTENT)
@@ -1064,7 +1080,7 @@ class APIBasicTests(TestsMixin, TestCase):
         # Ensure access keys are provided in response
         self.assertIn('access', refresh_resp.data)
         self.assertIn('access_expiration', refresh_resp.data)
-    
+
     @override_api_settings(JWT_AUTH_RETURN_EXPIRATION=True)
     @override_api_settings(USE_JWT=True)
     @override_api_settings(JWT_AUTH_COOKIE='xxx')


### PR DESCRIPTION
The PR resolves the issue https://github.com/iMerica/dj-rest-auth/issues/604