### PR TITLE
Fix default_url_generator

### DIFF
--- a/dj_rest_auth/forms.py
+++ b/dj_rest_auth/forms.py
@@ -21,7 +21,7 @@ if 'allauth' in settings.INSTALLED_APPS:
 
 def default_url_generator(request, user, temp_key):
     path = reverse(
-        'password_reset_confirm',
+        'rest_password_reset_confirm',
         args=[user_pk_to_url_str(user), temp_key],
     )
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -16,13 +16,7 @@ FAQ
     If you don't want to use API on that step, then just use ConfirmEmailView view from:
     django-allauth https://github.com/pennersr/django-allauth/blob/master/allauth/account/views.py
 
-
-2. I get an error: Reverse for 'password_reset_confirm' not found.
-
-    You need to add `password_reset_confirm` url into your ``urls.py`` (at the top of any other included urls). Please check the ``urls.py`` module inside demo app example for more details.
-
-
-3. How can I update UserProfile assigned to User model?
+2. How can I update UserProfile assigned to User model?
 
     Assuming you already have UserProfile model defined like this
 
@@ -42,7 +36,7 @@ FAQ
 
         from rest_framework import serializers
         from dj_rest_auth.serializers import UserDetailsSerializer
-        
+
         class UserProfileSerializer(serializers.ModelSerializer):
             class Meta:
                 model = UserProfile


### PR DESCRIPTION
This is the URL that this module defines:

    dj_rest_auth/urls.py:    path('password/reset/confirm/', PasswordResetConfirmView.as_view(), name='rest_password_reset_confirm'),

As such, the URL name it should use is rest_password_reset_confirm