### PR TITLE
chore(test): bump `django-allauth` to 0.62.1

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -119,7 +119,7 @@ class SocialLoginSerializer(serializers.Serializer):
                 )
 
             provider = adapter.get_provider()
-            scope = provider.get_scope(request)
+            scope = provider.get_scope_from_request(request)
             client = self.client_class(
                 request,
                 app.client_id,

--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -118,8 +118,6 @@ class SocialLoginSerializer(serializers.Serializer):
                     _('Define client_class in view'),
                 )
 
-            provider = adapter.get_provider()
-            scope = provider.get_scope_from_request(request)
             client = self.client_class(
                 request,
                 app.client_id,

--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -127,7 +127,6 @@ class SocialLoginSerializer(serializers.Serializer):
                 adapter.access_token_method,
                 adapter.access_token_url,
                 self.callback_url,
-                scope,
                 scope_delimiter=adapter.scope_delimiter,
                 headers=adapter.headers,
                 basic_auth=adapter.basic_auth,

--- a/dj_rest_auth/tests/requirements.pip
+++ b/dj_rest_auth/tests/requirements.pip
@@ -1,5 +1,5 @@
 coveralls==1.11.1
-django-allauth==0.61.1
+django-allauth[socialaccount]==0.62.1
 djangorestframework-simplejwt>=5.3.1
 flake8==3.8.4
 responses==0.12.1

--- a/dj_rest_auth/tests/test_serializers.py
+++ b/dj_rest_auth/tests/test_serializers.py
@@ -120,10 +120,7 @@ class TestSocialLoginSerializer(TestCase):
     def setUpTestData(cls):
         cls.request_data = {"access_token": "token1234"}
         cls.request = APIRequestFactory().post(cls.request_data, format='json')
-
-        middleware = SessionMiddleware(get_response=MagicMock())
-        middleware(cls.request)
-
+        cls.request.session = {}
         social_app = SocialApp.objects.create(
             provider='facebook',
             name='Facebook',
@@ -153,7 +150,7 @@ class TestSocialLoginSerializer(TestCase):
         serializer.is_valid()
         self.assertDictEqual(serializer.errors, self.NO_ADAPTER_CLASS_PRESENT)
 
-    @patch('allauth.socialaccount.providers.facebook.views.FacebookOAuth2Adapter.complete_login')
+    @patch('allauth.socialaccount.providers.facebook.flows.complete_login')
     @patch('allauth.socialaccount.adapter.DefaultSocialAccountAdapter.pre_social_login')
     def test_immediate_http_response_error(self, mock_pre_social_login, mock_fb_complete_login):
         dummy_view = SocialLoginView()

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'djangorestframework>=3.13.0',
     ],
     extras_require={
-        'with_social': ['django-allauth>=0.56.0,<0.62.0'],
+        'with_social': ['django-allauth[socialaccount]>=0.62.0,<=0.62.1'],
     },
     tests_require=[
         'coveralls>=1.11.1',


### PR DESCRIPTION
Bumps tests to support `django-allauth` 0.62.1.

Also fixes some incidental test breakages that came with the version bump.

Fixes #626.