### PR TITLE
fix: Return 400 in logout view when user is not authenticated

### DIFF
--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -135,7 +135,7 @@ class LogoutView(APIView):
 
     Accepts/Returns nothing.
     """
-    permission_classes = (AllowAny,)
+    permission_classes = (IsAuthenticated,)
     throttle_scope = 'dj_rest_auth'
 
     def get(self, request, *args, **kwargs):


### PR DESCRIPTION
Closes #439.

Currently `LogoutView` pretends from the code perspective to return `400` when user is not authenticated but since `permission_classes` is `AllowAny` it returns `200`.