### PR TITLE
Fix extras naming `with_social` -> `with-social`

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -44,7 +44,7 @@ You're good to go now!
 Registration (optional)
 -----------------------
 
-1. If you want to enable standard registration process you will need to install ``django-allauth`` by using ``pip install 'dj-rest-auth[with_social]'``.
+1. If you want to enable standard registration process you will need to install ``django-allauth`` by using ``pip install 'dj-rest-auth[with-social]'``.
 
 2. Add ``django.contrib.sites``, ``allauth``, ``allauth.account``, ``allauth.socialaccount`` and ``dj_rest_auth.registration`` apps to INSTALLED_APPS in your django settings.py:
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'djangorestframework>=3.13.0',
     ],
     extras_require={
-        'with_social': ['django-allauth>=0.56.0,<0.62.0'],
+        'with-social': ['django-allauth>=0.56.0,<0.62.0'],
     },
     tests_require=[
         'coveralls>=1.11.1',


### PR DESCRIPTION
Replace underscore with hyphen to conform with Core metadata specification https://packaging.python.org/en/latest/specifications/core-metadata/#provides-extra-multiple-use

Found need for this fix because poetry "normalizes" the extras, and when you export requirements.txt from poetry it breaks the extras