### PR TITLE
feat: default empty authentication_class for login and retistration

### DIFF
--- a/dj_rest_auth/registration/views.py
+++ b/dj_rest_auth/registration/views.py
@@ -34,6 +34,7 @@ sensitive_post_parameters_m = method_decorator(
 class RegisterView(CreateAPIView):
     serializer_class = api_settings.REGISTER_SERIALIZER
     permission_classes = api_settings.REGISTER_PERMISSION_CLASSES
+    authentication_classes = ()
     token_model = TokenModel
     throttle_scope = 'dj_rest_auth'
 

--- a/dj_rest_auth/views.py
+++ b/dj_rest_auth/views.py
@@ -36,6 +36,7 @@ class LoginView(GenericAPIView):
     Return the REST Framework Token Object's key.
     """
     permission_classes = (AllowAny,)
+    authentication_classes = ()
     serializer_class = api_settings.LOGIN_SERIALIZER
     throttle_scope = 'dj_rest_auth'
 


### PR DESCRIPTION
So that by default we don't have lock icon on swagger.

<img width="1113" alt="Screenshot 2024-06-10 at 16 25 32" src="https://github.com/iMerica/dj-rest-auth/assets/13653687/bfaf3a82-d74d-49fd-bc10-4ffca1714d0e">
