### PR TITLE
docs: Update Token Authentication sections to explain how to properly…

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -62,6 +62,8 @@ authentication in ``dj_rest_auth.views.LoginView``. The value is the dotted
 path to ``dj_rest_auth.serializers.TokenSerializer``, which is also the
 default.
 
+.. note:: This should be set to ``None`` together with ``TOKEN_MODEL`` if you don't want to use Token Authentication.
+
 ``JWT_SERIALIZER``
 ==================
 
@@ -142,6 +144,8 @@ The path to the model class for the token. The value is the dotted path to
 ``rest_framework.authtoken.models.Token``, which is also the default. If set to
 ``None`` token authentication will be disabled. In this case at least one of
 ``SESSION_LOGIN`` or ``USE_JWT`` must be enabled.
+
+.. note:: ``TOKEN_SERIALIZER`` should also be set to `None` if you don't want to use Token Authentication.
 
 ``TOKEN_CREATOR``
 =================


### PR DESCRIPTION
… disable it

## Background (can be skipped)

Just as an FYI for anyone who might be looking for this exact issue.

I was using `drf-spectacular` together with `dj-rest-auth` and was getting a constant error:
```
File "/root/.local/share/virtualenvs/facturing-be-yU94o058/lib/python3.11/site-packages/rest_framework/utils/model_meta.py", line 35, in get_field_info
    opts = model._meta.concrete_model._meta
           ^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute '_meta'
```

The problem was that I was not using Token Authentication but rather Session Authentication, and thus, following the docs, I set `TOKEN_MODEL` to `None`.

The problem comes when the `TokenSerializer` is still active, and tries to get the `Token` model, which is overridden by the `TOKEN_MODEL` setting. This causes the error above.

## Fix

To properly disable Token Authentication, the `TOKEN_SERIALIZER` setting should **also** be set to `None`, together with `TOKEN_MODEL`.

I've added a couple of notes under `TOKEN_SERIALIZER` and `TOKEN_MODEL` specifying that both need to be set to `None` in order to fully disable the Token Authentication functionality.