### PR TITLE
update requirements for unittest-xml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         django-version: ['3.2', '4.2', '5.0']
         exclude:
           - python-version: '3.8'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         django-version: ['3.2', '4.2', '5.0']
         exclude:
           - python-version: '3.8'

--- a/dj_rest_auth/tests/requirements.pip
+++ b/dj_rest_auth/tests/requirements.pip
@@ -3,4 +3,4 @@ django-allauth==0.61.1
 djangorestframework-simplejwt>=5.3.1
 flake8==3.8.4
 responses==0.12.1
-unittest-xml-reporting==3.0.4
+unittest-xml-reporting==3.2.0

--- a/dj_rest_auth/tests/test_api.py
+++ b/dj_rest_auth/tests/test_api.py
@@ -731,7 +731,7 @@ class APIBasicTests(TestsMixin, TestCase):
         resp = self.post(self.login_url, data=payload, status_code=200)
         self.assertEqual(['jwt-auth'], list(resp.cookies.keys()))
         resp = self.get('/protected-view/')
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
     @modify_settings(INSTALLED_APPS={'remove': ['rest_framework_simplejwt.token_blacklist']})
     @override_api_settings(USE_JWT=True)
@@ -794,9 +794,9 @@ class APIBasicTests(TestsMixin, TestCase):
         self.assertEqual('access' in self.response.json.keys(), True)
         self.token = self.response.json['access']
         claims = decode_jwt(self.token, settings.SECRET_KEY, algorithms='HS256')
-        self.assertEquals(claims['user_id'], 1)
-        self.assertEquals(claims['name'], 'person')
-        self.assertEquals(claims['email'], 'person1@world.com')
+        self.assertEqual(claims['user_id'], 1)
+        self.assertEqual(claims['name'], 'person')
+        self.assertEqual(claims['email'], 'person1@world.com')
 
     @override_api_settings(USE_JWT=True)
     @override_api_settings(JWT_AUTH_COOKIE='jwt-auth')
@@ -819,11 +819,11 @@ class APIBasicTests(TestsMixin, TestCase):
         self.assertEqual(['jwt-auth'], list(resp.cookies.keys()))
         token = resp.cookies.get('jwt-auth').value
         claims = decode_jwt(token, settings.SECRET_KEY, algorithms='HS256')
-        self.assertEquals(claims['user_id'], 1)
-        self.assertEquals(claims['name'], 'person')
-        self.assertEquals(claims['email'], 'person1@world.com')
+        self.assertEqual(claims['user_id'], 1)
+        self.assertEqual(claims['name'], 'person')
+        self.assertEqual(claims['email'], 'person1@world.com')
         resp = self.get('/protected-view/')
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
     @override_api_settings(USE_JWT=True)
     @override_api_settings(JWT_AUTH_COOKIE='jwt-auth')
@@ -850,22 +850,22 @@ class APIBasicTests(TestsMixin, TestCase):
 
         resp = client.post(self.login_url, payload)
         self.assertTrue('jwt-auth' in list(client.cookies.keys()))
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
         # TEST WITH JWT AUTH HEADER
         jwtclient = APIClient(enforce_csrf_checks=True)
         token = resp.data['access']
         resp = jwtclient.get('/protected-view/', HTTP_AUTHORIZATION='Bearer ' + token)
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
         resp = jwtclient.post('/protected-view/', {}, HTTP_AUTHORIZATION='Bearer ' + token)
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
         # TEST WITH COOKIES
         resp = client.get('/protected-view/')
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
         resp = client.post('/protected-view/', {})
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
     @override_api_settings(USE_JWT=True)
     @override_api_settings(JWT_AUTH_COOKIE='jwt-auth')
@@ -896,30 +896,30 @@ class APIBasicTests(TestsMixin, TestCase):
         resp = client.post(self.login_url, payload)
         self.assertTrue('jwt-auth' in list(client.cookies.keys()))
         self.assertTrue('csrftoken' in list(client.cookies.keys()))
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
         # TEST WITH JWT AUTH HEADER
         jwtclient = APIClient(enforce_csrf_checks=True)
         token = resp.data['access']
         resp = jwtclient.get('/protected-view/')
-        self.assertEquals(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)
         resp = jwtclient.get('/protected-view/', HTTP_AUTHORIZATION='Bearer ' + token)
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
         resp = jwtclient.post('/protected-view/', {})
-        self.assertEquals(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)
         resp = jwtclient.post('/protected-view/', {}, HTTP_AUTHORIZATION='Bearer ' + token)
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
         # TEST WITH COOKIES
         resp = client.get('/protected-view/')
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
         # fail w/o csrftoken in payload
         resp = client.post('/protected-view/', {})
-        self.assertEquals(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)
 
         csrfparam = {'csrfmiddlewaretoken': csrftoken}
         resp = client.post('/protected-view/', csrfparam)
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
     @override_api_settings(USE_JWT=True)
     @override_api_settings(JWT_AUTH_COOKIE='jwt-auth')
@@ -949,26 +949,26 @@ class APIBasicTests(TestsMixin, TestCase):
 
         # fail w/o csrftoken in payload
         resp = client.post(self.login_url, payload)
-        self.assertEquals(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)
 
         payload['csrfmiddlewaretoken'] = csrftoken
         resp = client.post(self.login_url, payload)
         self.assertTrue('jwt-auth' in list(client.cookies.keys()))
         self.assertTrue('csrftoken' in list(client.cookies.keys()))
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
         # TEST WITH JWT AUTH HEADER does not make sense
 
         # TEST WITH COOKIES
         resp = client.get('/protected-view/')
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
         # fail w/o csrftoken in payload
         resp = client.post('/protected-view/', {})
-        self.assertEquals(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)
 
         csrfparam = {'csrfmiddlewaretoken': csrftoken}
         resp = client.post('/protected-view/', csrfparam)
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
     @override_api_settings(USE_JWT=True)
     @override_api_settings(JWT_AUTH_COOKIE='jwt-auth')
@@ -998,26 +998,26 @@ class APIBasicTests(TestsMixin, TestCase):
 
         # fail w/o csrftoken in payload
         resp = client.post(self.login_url, payload)
-        self.assertEquals(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)
 
         payload['csrfmiddlewaretoken'] = csrftoken
         resp = client.post(self.login_url, payload)
         self.assertTrue('jwt-auth' in list(client.cookies.keys()))
         self.assertTrue('csrftoken' in list(client.cookies.keys()))
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
         # TEST WITH JWT AUTH HEADER does not make sense
 
         # TEST WITH COOKIES
         resp = client.get('/protected-view/')
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
         # fail w/o csrftoken in payload
         resp = client.post('/protected-view/', {})
-        self.assertEquals(resp.status_code, 403)
+        self.assertEqual(resp.status_code, 403)
 
         csrfparam = {'csrfmiddlewaretoken': csrftoken}
         resp = client.post('/protected-view/', csrfparam)
-        self.assertEquals(resp.status_code, 200)
+        self.assertEqual(resp.status_code, 200)
 
     @override_api_settings(JWT_AUTH_RETURN_EXPIRATION=True)
     @override_api_settings(USE_JWT=True)


### PR DESCRIPTION
Hi, i tried to launch the test with python 3.12 and i receive this error:
Traceback (most recent call last):
```bash
  File "/home/fildev/git_projects/dj-rest-auth/runtests.py", line 26, in <module>
    runtests()
  File "/home/fildev/git_projects/dj-rest-auth/runtests.py", line 17, in runtests
    TestRunner = get_runner(settings)
                 ^^^^^^^^^^^^^^^^^^^^
  File "/home/fildev/git_projects/dj-rest-auth/.venv/lib/python3.12/site-packages/django/test/utils.py", line 380, in get_runner
    test_module = __import__(test_module_name, {}, {}, test_path[-1])
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/fildev/git_projects/dj-rest-auth/.venv/lib/python3.12/site-packages/xmlrunner/__init__.py", line 11, in <module>
    from .runner import XMLTestRunner
  File "/home/fildev/git_projects/dj-rest-auth/.venv/lib/python3.12/site-packages/xmlrunner/runner.py", line 6, in <module>
    from .unittest import TextTestRunner, TestProgram
  File "/home/fildev/git_projects/dj-rest-auth/.venv/lib/python3.12/site-packages/xmlrunner/unittest.py", line 8, in <module>
    from unittest import TestResult, _TextTestResult
ImportError: cannot import name '_TextTestResult' from 'unittest' (/usr/lib/python3.12/unittest/__init__.py). Did you mean: 'TextTestResult'?
```
so i read the file /usr/lib/python3.12/unittest/__init__.py and how it's changed in the history and _TextTestResult is deprecated, from 3.12 it's removed. upgrade unittest-xml-reporting to latest version resolve the problem and tests work, i also added python 3.12 to list of test on workflow.

I'm sorry if i wrong something, this is my first contribution on github on a public project
