### PR TITLE
FIX: Modify the location of post_signup call for social login

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -187,7 +187,7 @@ class SocialLoginSerializer(serializers.Serializer):
                 raise serializers.ValidationError(
                     _('User is already registered with this e-mail address.'),
                 ) from ex
-            self.post_signup(login, attrs)
+        self.post_signup(login, attrs)
 
         attrs['user'] = login.account.user
 


### PR DESCRIPTION
The processing location of "post_signup()" is within "if not login.is_existing", so the function cannot be called during normal social login.