### PR TITLE
Change `path` to `re_path` and add `?$` to make trailing slash optional

### DIFF
--- a/dj_rest_auth/registration/urls.py
+++ b/dj_rest_auth/registration/urls.py
@@ -6,8 +6,8 @@ from .views import RegisterView, VerifyEmailView, ResendEmailVerificationView
 
 urlpatterns = [
     path('', RegisterView.as_view(), name='rest_register'),
-    path('verify-email/', VerifyEmailView.as_view(), name='rest_verify_email'),
-    path('resend-email/', ResendEmailVerificationView.as_view(), name="rest_resend_email"),
+    re_path(r'verify-email/?$', VerifyEmailView.as_view(), name='rest_verify_email'),
+    re_path(r'resend-email/?$', ResendEmailVerificationView.as_view(), name="rest_resend_email"),
 
     # This url is used by django-allauth and empty TemplateView is
     # defined just to allow reverse() call inside app, for example when email
@@ -24,8 +24,8 @@ urlpatterns = [
         r'^account-confirm-email/(?P<key>[-:\w]+)/$', TemplateView.as_view(),
         name='account_confirm_email',
     ),
-    path(
-        'account-email-verification-sent/', TemplateView.as_view(),
+    re_path(
+        r'account-email-verification-sent/?$', TemplateView.as_view(),
         name='account_email_verification_sent',
     ),
 ]

--- a/dj_rest_auth/urls.py
+++ b/dj_rest_auth/urls.py
@@ -1,4 +1,4 @@
-from django.urls import path
+from django.urls import re_path
 
 from dj_rest_auth.app_settings import api_settings
 
@@ -10,13 +10,13 @@ from dj_rest_auth.views import (
 
 urlpatterns = [
     # URLs that do not require a session or valid token
-    path('password/reset/', PasswordResetView.as_view(), name='rest_password_reset'),
-    path('password/reset/confirm/', PasswordResetConfirmView.as_view(), name='rest_password_reset_confirm'),
-    path('login/', LoginView.as_view(), name='rest_login'),
+    re_path(r'password/reset/?$', PasswordResetView.as_view(), name='rest_password_reset'),
+    re_path(r'password/reset/confirm/?$', PasswordResetConfirmView.as_view(), name='rest_password_reset_confirm'),
+    re_path(r'login/?$', LoginView.as_view(), name='rest_login'),
     # URLs that require a user to be logged in with a valid session / token.
-    path('logout/', LogoutView.as_view(), name='rest_logout'),
-    path('user/', UserDetailsView.as_view(), name='rest_user_details'),
-    path('password/change/', PasswordChangeView.as_view(), name='rest_password_change'),
+    re_path(r'logout/?$', LogoutView.as_view(), name='rest_logout'),
+    re_path(r'user/?$', UserDetailsView.as_view(), name='rest_user_details'),
+    re_path(r'password/change/?$', PasswordChangeView.as_view(), name='rest_password_change'),
 ]
 
 if api_settings.USE_JWT:
@@ -25,6 +25,6 @@ if api_settings.USE_JWT:
     from dj_rest_auth.jwt_auth import get_refresh_view
 
     urlpatterns += [
-        path('token/verify/', TokenVerifyView.as_view(), name='token_verify'),
-        path('token/refresh/', get_refresh_view().as_view(), name='token_refresh'),
+        re_path(r'token/verify/?$', TokenVerifyView.as_view(), name='token_verify'),
+        re_path(r'token/refresh/?$', get_refresh_view().as_view(), name='token_refresh'),
     ]


### PR DESCRIPTION
On urls.py change `path` to `re_path` and add `?$` to make trailing slash optional

Fixes: https://github.com/iMerica/dj-rest-auth/issues/647