### PR TITLE
fix(auth): fix incorrect call to get_scope

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -14,7 +14,7 @@ try:
     from allauth.account.adapter import get_adapter
     from allauth.account.utils import setup_user_email
     from allauth.socialaccount.helpers import complete_social_login
-    from allauth.socialaccount.models import SocialAccount, EmailAddress
+    from allauth.socialaccount.models import EmailAddress, SocialAccount
     from allauth.socialaccount.providers.base import AuthProcess
     from allauth.utils import get_username_max_length
 except ImportError:
@@ -119,7 +119,7 @@ class SocialLoginSerializer(serializers.Serializer):
                 )
 
             provider = adapter.get_provider()
-            scope = provider.get_scope(request)
+            scope = provider.get_scope_from_request(request)
             client = self.client_class(
                 request,
                 app.client_id,


### PR DESCRIPTION
It appears that since this [commit](https://github.com/pennersr/django-allauth/commit/7c6657f7a1348adcb419ae040449752c3b87e8de#diff-7ce21ab54e4634f40e6109ec545c8c3ed6c69702ec427daeb527022e965352b6) in allauth that dj-rest-auth should call `get_scope_from_request(request)` in the SocialLoginSerializer. 

When validating the provided code the current implementation throws this exception:

`| TypeError: OAuth2Provider.get_scope() takes 1 positional argument but 2 were given`