### PR TITLE
Fix: Resolve Duplicate `scope` and `scope_delimiter` Parameters in SocialLoginSerializer

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -118,8 +118,6 @@ class SocialLoginSerializer(serializers.Serializer):
                     _('Define client_class in view'),
                 )
 
-            provider = adapter.get_provider()
-            scope = provider.get_scope_from_request(request)
             client = self.client_class(
                 request,
                 app.client_id,
@@ -127,7 +125,6 @@ class SocialLoginSerializer(serializers.Serializer):
                 adapter.access_token_method,
                 adapter.access_token_url,
                 self.callback_url,
-                scope,
                 scope_delimiter=adapter.scope_delimiter,
                 headers=adapter.headers,
                 basic_auth=adapter.basic_auth,


### PR DESCRIPTION
## Problem
The `SocialLoginSerializer` passes both `scope` and `scope_delimiter` to the `OAuth2Client` constructor, causing a `TypeError` due to duplicate arguments for `scope_delimiter`.

## Solution
- Removed the redundant `scope` parameter while preserving `scope_delimiter`.
- Ensured seamless integration with OAuth2 providers.

## Impact
This resolves the error and ensures compatibility with OAuth2 flows like Google Login. The fix is backward-compatible and does not affect other functionalities.

## Visuals
![dj-rest-auth scope_delimiter bug](https://github.com/user-attachments/assets/cc58128e-4751-42f1-9f93-351f4f6924dd)
![OAuth2Client init method](https://github.com/user-attachments/assets/3e296d1e-7e78-4afa-b855-a61048cce707)
![SocialLoginSerializer multiple scope_delimiter](https://github.com/user-attachments/assets/9f6299e7-9f5d-4753-849f-92909d7e28a0)
