### PR TITLE
build and publish wheels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,9 @@ jobs:
           python-version: 3.8
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
+          python -m pip install --upgrade build
       - name: Build
-        run: python3 setup.py sdist
+        run: python3 -m build
       - name: Store artifacts
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
I notice that this package publishes only source distributions, so that every user has to build the wheel themselves. Better for package owners to build and publish wheels once and for all.

Use of setup.py as a command line tool is [deprecated](https://packaging.python.org/en/latest/discussions/setup-py-deprecated/), I have switched to use the most often recommended alternative.

I did not find a publish workflow, so this pull request only updates the pipelines to _build_ wheels.  Please also update your routine so that you also _publish_ the built wheel.