### PR TITLE
fix(serializers): update email and username required fields to use SI…

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -225,9 +225,9 @@ class RegisterSerializer(serializers.Serializer):
     username = serializers.CharField(
         max_length=get_username_max_length(),
         min_length=allauth_account_settings.USERNAME_MIN_LENGTH,
-        required=allauth_account_settings.USERNAME_REQUIRED,
+        required=allauth_account_settings.SIGNUP_FIELDS.get('username', {}).get('required', True),
     )
-    email = serializers.EmailField(required=allauth_account_settings.EMAIL_REQUIRED)
+    email = serializers.EmailField(required=allauth_account_settings.SIGNUP_FIELDS.get('email', {}).get('required', True))
     password1 = serializers.CharField(write_only=True)
     password2 = serializers.CharField(write_only=True)
 
@@ -285,4 +285,4 @@ class VerifyEmailSerializer(serializers.Serializer):
 
 
 class ResendEmailVerificationSerializer(serializers.Serializer):
-    email = serializers.EmailField(required=allauth_account_settings.EMAIL_REQUIRED)
+    email = serializers.EmailField(required=allauth_account_settings.SIGNUP_FIELDS.get('email', {}).get('required', True))


### PR DESCRIPTION
# Fix deprecated allauth settings usage

## Description
This PR fixes deprecation warnings by updating the serializers to use the new 
allauth settings structure. Specifically, it updates from deprecated settings like 
`USERNAME_REQUIRED` and `EMAIL_REQUIRED` to the new `SIGNUP_FIELDS` dictionary structure.

## Changes
- Updated `RegisterSerializer` to use `SIGNUP_FIELDS` dictionary for username and email required fields
- Updated `ResendEmailVerificationSerializer` to use `SIGNUP_FIELDS` dictionary for email required field
- Added fallbacks to maintain backward compatibility

## Related Issues
Fixes deprecation warnings:
- `app_settings.USERNAME_REQUIRED is deprecated, use: app_settings.SIGNUP_FIELDS['username']['required']`
- `app_settings.EMAIL_REQUIRED is deprecated, use: app_settings.SIGNUP_FIELDS['email']['required']`

## Testing
All tests pass successfully with the updated settings usage.