### PR TITLE
Refactor to use SIGNUP_FIELDS for username and email requirement checks, fix deprecated settings warnings

### DIFF
--- a/dj_rest_auth/registration/serializers.py
+++ b/dj_rest_auth/registration/serializers.py
@@ -225,9 +225,9 @@ class RegisterSerializer(serializers.Serializer):
     username = serializers.CharField(
         max_length=get_username_max_length(),
         min_length=allauth_account_settings.USERNAME_MIN_LENGTH,
-        required=allauth_account_settings.USERNAME_REQUIRED,
+        required=allauth_account_settings.SIGNUP_FIELDS.get('username', {}).get('required', True),
     )
-    email = serializers.EmailField(required=allauth_account_settings.EMAIL_REQUIRED)
+    email = serializers.EmailField(required=allauth_account_settings.SIGNUP_FIELDS.get('email', {}).get('required', True))
     password1 = serializers.CharField(write_only=True)
     password2 = serializers.CharField(write_only=True)
 


### PR DESCRIPTION
Replaced deprecated USERNAME_REQUIRED and EMAIL_REQUIRED usage with the recommended SIGNUP_FIELDS approach from django-allauth.
Fixes warnings when using updated versions of django-allauth.

This avoids deprecation warnings in recent versions of the package.

@iMerica 👋 — let me know if this approach works. Happy to help further!