### PR TITLE
Fix password reset confirm URL name to match existing endpoint

### DIFF
--- a/dj_rest_auth/forms.py
+++ b/dj_rest_auth/forms.py
@@ -21,7 +21,7 @@ if 'allauth' in settings.INSTALLED_APPS:
 
 def default_url_generator(request, user, temp_key):
     path = reverse(
-        'password_reset_confirm',
+        'rest_password_reset_confirm',
         args=[user_pk_to_url_str(user), temp_key],
     )
 


### PR DESCRIPTION
Updated the password reset URL to use 'rest_password_reset_confirm' instead of 'password_reset_confirm'.