### PR TITLE
Avoid AUTHENTICATION_METHOD warning when LOGIN_METHODS is defined

### DIFF
--- a/dj_rest_auth/forms.py
+++ b/dj_rest_auth/forms.py
@@ -72,12 +72,14 @@ class AllAuthPasswordResetForm(DefaultPasswordResetForm):
                 'token': temp_key,
                 'uid': uid,
             }
+            has_login_methods = bool(getattr(allauth_account_settings, "LOGIN_METHODS", None))
             if (
-                getattr(allauth_account_settings, "LOGIN_METHODS", None) and  # noqa: W504
+                has_login_methods and  # noqa: W504
                 allauth_account_settings.AuthenticationMethod.EMAIL not in allauth_account_settings.LOGIN_METHODS
             ):
                 context['username'] = user_username(user)
             elif (
+                not has_login_methods and  # noqa: W504
                 allauth_account_settings.AUTHENTICATION_METHOD != allauth_account_settings.AuthenticationMethod.EMAIL
             ):
                 # AUTHENTICATION_METHOD is deprecated


### PR DESCRIPTION
Even if `LOGIN_METHODS` are configured, the password reset form will always access the `AUTHENTICATION_METHOD` when using only email.  This change will only check `AUTHENTICATION_METHOD` if there were no `LOGIN_METHODS` defined.